### PR TITLE
Use system number format for balance display

### DIFF
--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -1,6 +1,11 @@
 import lvgl as lv
 
 from mpos import Activity, Intent, ConnectivityManager, MposKeyboard, DisplayMetrics, SharedPreferences, SettingsActivity, WidgetAnimator
+try:
+    from mpos import NumberFormat
+    _has_number_format = True
+except ImportError:
+    _has_number_format = False
 
 from confetti import Confetti
 from fullscreen_qr import FullscreenQR
@@ -247,16 +252,18 @@ class DisplayWallet(Activity):
         self.update_payments_label_font()
 
     def float_to_string(self, value, decimals):
-        # Format float to string with fixed-point notation and specified decimal places
+        if _has_number_format:
+            return NumberFormat.format_number(value, decimals)
+        # Fallback for firmware without NumberFormat
         s = "{:.{}f}".format(value, decimals)
-        # Remove trailing zeros and decimal point if no decimals remain
         return s.rstrip("0").rstrip(".")
 
     def display_balance(self, balance):
          #print(f"displaying balance {balance}")
          if self.balance_mode == 0:  # sats
              #balance_text = "丰 " + str(balance) # font doesnt support it
-             balance_text = str(int(round(balance))) + " sat"
+             sats = int(round(balance))
+             balance_text = (NumberFormat.format_number(sats) if _has_number_format else str(sats)) + " sat"
              if balance > 1:
                  balance_text += "s"
          elif self.balance_mode == 1:  # bits (1 bit = 100 sats)


### PR DESCRIPTION
## Summary
- Uses the MicroPythonOS `NumberFormat` utility for locale-aware number formatting in balance display
- Sats balance now gets thousands separators (e.g. "1,234,567 sats" in US, "1.234.567 sats" in European format)
- Decimal values (bits, μBTC, mBTC, BTC) use the configured decimal separator
- Falls back to existing hardcoded formatting on firmware without `NumberFormat` (graceful import with try/except)

## Dependency
Requires [MicroPythonOS#94](https://github.com/MicroPythonOS/MicroPythonOS/pull/94) for full functionality. Works without it — falls back to current US-style formatting.

## Test plan
- [ ] On firmware **with** NumberFormat: change number format in Settings → balance display updates accordingly
- [ ] On firmware **without** NumberFormat: app launches normally, balance displays as before (no crash)
- [ ] Verify all 5 balance modes (sats, bits, μBTC, mBTC, BTC) format correctly with different locale settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)