### PR TITLE
Cache wallet data for instant display on boot

### DIFF
--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -9,6 +9,7 @@ except ImportError:
 
 from confetti import Confetti
 from fullscreen_qr import FullscreenQR
+import wallet_cache
 
 # Import wallet modules at the top so they're available when sys.path is restored
 # This prevents ImportError when switching wallet types after the app has started
@@ -282,8 +283,29 @@ class DisplayWallet(Activity):
     def _splash_done(self, timer):
         """Called after splash duration. Fade out splash and show appropriate screen."""
         WidgetAnimator.hide_widget(self.splash_container, duration=500)
+        # Show cached data immediately while waiting for network
+        self._load_and_display_cache()
         cm = ConnectivityManager.get()
         self.network_changed(cm.is_online())
+
+    def _load_and_display_cache(self):
+        """Load cached wallet data and display it immediately."""
+        if not self.prefs.get_string("wallet_type"):
+            return  # no wallet configured, nothing to show
+        self.show_wallet_screen()
+        cached_balance = wallet_cache.load_cached_balance()
+        if cached_balance is not None:
+            print(f"Cache: displaying cached balance {cached_balance}")
+            self.display_balance(cached_balance)
+        cached_payments = wallet_cache.load_cached_payments()
+        if cached_payments is not None and len(cached_payments) > 0:
+            print(f"Cache: displaying {len(cached_payments)} cached payments")
+            self.payments_label.set_text(str(cached_payments))
+        cached_receive_code = wallet_cache.load_cached_static_receive_code()
+        if cached_receive_code:
+            print(f"Cache: displaying cached QR code")
+            self.receive_qr_data = cached_receive_code
+            self.receive_qr.update(cached_receive_code, len(cached_receive_code))
 
     def update_payments_label_font(self):
         self.payments_label.set_style_text_font(self.payments_label_fonts[self.payments_label_current_font], lv.PART.MAIN)

--- a/com.lightningpiggy.displaywallet/assets/wallet.py
+++ b/com.lightningpiggy.displaywallet/assets/wallet.py
@@ -1,11 +1,11 @@
 from mpos import TaskManager
 
 from unique_sorted_list import UniqueSortedList
+import wallet_cache
 
 class Wallet:
 
     # Public variables
-    # These values could be loading from a cache.json file at __init__
     last_known_balance = None
     payment_list = None
     static_receive_code = None
@@ -37,6 +37,7 @@ class Wallet:
         if self.last_known_balance is None:
             self.last_known_balance = new_balance
             print("First balance received")
+            wallet_cache.save_cache(balance=new_balance)
             if self.balance_updated_cb:
                 self.balance_updated_cb(0)
             # optional: fetch payments once on initial connect
@@ -48,6 +49,7 @@ class Wallet:
         if new_balance != self.last_known_balance:
             print("Balance changed!")
             self.last_known_balance = new_balance
+            wallet_cache.save_cache(balance=new_balance)
             print("Calling balance_updated_cb")
             if self.balance_updated_cb:
                 self.balance_updated_cb(sats_added)
@@ -61,6 +63,7 @@ class Wallet:
             return
         print("handle_new_payment")
         self.payment_list.add(new_payment)
+        wallet_cache.save_cache(payments=self.payment_list)
         self.payments_updated_cb()
 
     def handle_new_payments(self, new_payments):
@@ -70,6 +73,7 @@ class Wallet:
         if self.payment_list != new_payments:
             print("new list of payments")
             self.payment_list = new_payments
+            wallet_cache.save_cache(payments=self.payment_list)
             self.payments_updated_cb()
 
     def handle_new_static_receive_code(self, new_static_receive_code):
@@ -80,6 +84,7 @@ class Wallet:
         if self.static_receive_code != new_static_receive_code:
             print("it's really a new static_receive_code")
             self.static_receive_code = new_static_receive_code
+            wallet_cache.save_cache(static_receive_code=new_static_receive_code)
             if self.static_receive_code_updated_cb:
                 self.static_receive_code_updated_cb()
         else:

--- a/com.lightningpiggy.displaywallet/assets/wallet_cache.py
+++ b/com.lightningpiggy.displaywallet/assets/wallet_cache.py
@@ -1,0 +1,74 @@
+import json
+import os
+
+from payment import Payment
+from unique_sorted_list import UniqueSortedList
+
+CACHE_FILE = "M:cache/wallet_cache.json"
+CACHE_DIR = "M:cache"
+
+
+def _ensure_cache_dir():
+    try:
+        os.makedirs(CACHE_DIR)
+    except OSError:
+        pass  # already exists
+
+
+def load_cache():
+    """Load cached wallet data from flash. Returns dict or None."""
+    try:
+        with open(CACHE_FILE, "r") as f:
+            return json.load(f)
+    except Exception as e:
+        print(f"Cache: could not load ({e})")
+        return None
+
+
+def save_cache(balance=None, static_receive_code=None, payments=None):
+    """Save wallet data to flash cache. Only writes provided fields."""
+    _ensure_cache_dir()
+    # Load existing cache to merge
+    existing = load_cache() or {}
+    if balance is not None:
+        existing["balance"] = balance
+    if static_receive_code is not None:
+        existing["static_receive_code"] = static_receive_code
+    if payments is not None:
+        existing["payments"] = [
+            {"epoch_time": p.epoch_time, "amount_sats": p.amount_sats, "comment": p.comment}
+            for p in payments
+        ]
+    try:
+        with open(CACHE_FILE, "w") as f:
+            json.dump(existing, f)
+        print("Cache: saved")
+    except Exception as e:
+        print(f"Cache: could not save ({e})")
+
+
+def load_cached_balance():
+    """Returns cached balance (int) or None."""
+    data = load_cache()
+    if data and "balance" in data:
+        return data["balance"]
+    return None
+
+
+def load_cached_static_receive_code():
+    """Returns cached static receive code (str) or None."""
+    data = load_cache()
+    if data and "static_receive_code" in data:
+        return data["static_receive_code"]
+    return None
+
+
+def load_cached_payments():
+    """Returns cached payments as UniqueSortedList or None."""
+    data = load_cache()
+    if data and "payments" in data:
+        payment_list = UniqueSortedList()
+        for p in data["payments"]:
+            payment_list.add(Payment(p["epoch_time"], p["amount_sats"], p["comment"]))
+        return payment_list
+    return None


### PR DESCRIPTION
## Summary
- Cache balance, payment QR code, and recent transactions to flash storage (`M:cache/wallet_cache.json`)
- On boot, display cached data instantly while WiFi connects and fresh data is fetched in the background
- If WiFi is unavailable, cached data remains on screen instead of a blank/loading state

## New boot flow
1. Power on → show splash (2s)
2. Splash done → **instantly display cached balance + QR + payments**
3. WiFi connects → fetch fresh data in background
4. If data changed → update display + save new cache
5. If WiFi unavailable → cached data stays on screen

## Files changed
- **New:** `wallet_cache.py` — JSON-based cache read/write to flash
- **Modified:** `wallet.py` — save cache whenever balance, payments, or receive code change
- **Modified:** `displaywallet.py` — load and display cache on boot before network check

## Test plan
- [ ] First boot (no cache): should behave as before — fetch everything, display, save cache
- [ ] Reboot: should instantly show cached data, then update from network
- [ ] Turn off WiFi: device should show cached data (still useful)
- [ ] Receive a payment, wake device: should show updated balance after background fetch
- [ ] Change wallet settings: new wallet data should overwrite old cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)