### PR TITLE
Fix light mode background to match QR code

### DIFF
--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -53,6 +53,7 @@ class DisplayWallet(Activity):
     def onCreate(self):
         self.prefs = SharedPreferences("com.lightningpiggy.displaywallet")
         self.main_screen = lv.obj()
+        self.main_screen.set_style_bg_color(lv.color_white(), lv.PART.MAIN)
         self.main_screen.set_style_pad_all(0, lv.PART.MAIN)
         # This line needs to be drawn first, otherwise it's over the balance label and steals all the clicks!
         balance_line = lv.line(self.main_screen)


### PR DESCRIPTION
## Summary
- Set main screen background to white in light mode
- Previously inherited LVGL default (slight grey), which didn't match the white QR code background

One-line change in `displaywallet.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)