### PR TITLE
Show cached payments when payment fetch fails

### DIFF
--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -636,7 +636,12 @@ class DisplayWallet(Activity):
         # Mark as connected even if balance == 0
         if getattr(self.wallet, "payment_list", None) is not None:
             if len(self.wallet.payment_list) == 0:
-                self.payments_label.set_text("Connected.\nNo payments yet.")
+                # Don't overwrite cached payments with "no payments" message
+                cached = wallet_cache.load_cached_payments()
+                if cached and len(cached) > 0:
+                    self.payments_label.set_text(str(cached))
+                else:
+                    self.payments_label.set_text("Connected.\nNo payments yet.")
             else:
                 self.payments_label.set_text(str(self.wallet.payment_list))
         else:


### PR DESCRIPTION
## Summary
- When balance fetch succeeds but payments fetch fails (e.g. flaky WiFi/SSL errors), the wallet's `payment_list` is empty and "Connected. No payments yet." was overwriting previously cached transactions
- Now falls back to cached payments from `wallet_cache` if the live payment list is empty but cached data exists
- Discovered during real-world testing with intermittent WiFi — the `-29312` SSL error caused payments to disappear while balance stayed visible

## Test plan
- [ ] With cached data + working network: shows live payments (no change)
- [ ] With cached data + failed payments fetch: shows cached payments instead of "No payments yet."
- [ ] With no cached data + failed payments fetch: shows "Connected. No payments yet." (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)