### PR TITLE
Preserve cached payments when WiFi goes offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.2.4
+=====
+- Preserve cached payments on screen when WiFi goes offline
+
 0.2.3
 =====
 - Use NumberFormat framework for decimal and thousands separators

--- a/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
+++ b/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
@@ -3,10 +3,10 @@
 "publisher": "LightningPiggy Foundation",
 "short_description": "Display wallet that shows balance, transactions, receive QR code etc.",
 "long_description": "See https://www.LightningPiggy.com",
-"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.2.3_64x64.png",
-"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.2.3.mpk",
+"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.2.4_64x64.png",
+"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.2.4.mpk",
 "fullname": "com.lightningpiggy.displaywallet",
-"version": "0.2.3",
+"version": "0.2.4",
 "category": "finance",
 "activities": [
     {

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -483,8 +483,10 @@ class DisplayWallet(Activity):
             self.show_welcome_screen()
             return
         if self.wallet:
-            self.wallet.stop() # don't stop the wallet for the fullscreen QR activity
-        self.payments_label.set_text(f"WiFi is not connected, can't talk to wallet...")
+            self.wallet.stop()
+        # Don't overwrite cached data with offline message
+        if not (hasattr(self, '_last_balance') and self._last_balance):
+            self.payments_label.set_text(f"WiFi is not connected, can't talk to wallet...")
 
     def show_welcome_screen(self):
         """Hide wallet widgets, show welcome container."""


### PR DESCRIPTION
## Summary
- When WiFi times out (e.g. 10 failed connection attempts), `went_offline()` was overwriting cached transaction data with "WiFi is not connected, can't talk to wallet..."
- Now keeps cached data on screen if available, consistent with the existing guards in `error_cb()` and `went_online()`
- Follow-up to #19 which fixed the same issue in `balance_updated_cb()` — this covers the remaining `went_offline()` path

## The three places cached data could be overwritten
1. `balance_updated_cb` — "Connected. No payments yet." — fixed in #19 ✅
2. `went_online` — "Connecting to backend..." — fixed in #18 ✅
3. **`went_offline`** — "WiFi is not connected..." — **fixed in this PR**

## Merge checklist
- [x] CHANGELOG.md updated
- [x] Unit tests: `test_displaywallet_offline_cache.py` (5 tests covering cache preservation with/without cached data, zero balance, missing attribute)
- [x] No settings changes — no migration needed
- [x] Small focused diff — only `went_offline()` change + CHANGELOG, no unrelated import changes
- [x] Rebased on latest upstream/master — no conflicts with #21

## Test plan
- [x] `./tests/unittest.sh tests/test_displaywallet_offline_cache.py` — 5 tests pass
- [ ] Boot with flaky WiFi that times out: cached balance + payments + QR stay visible
- [ ] Boot with no WiFi configured: shows "WiFi is not connected..." (no cache to preserve)
- [ ] Boot with working WiFi: normal behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)