### PR TITLE
Fix NameError: _has_number_format not defined (crash on boot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+0.2.4
+=====
+- Fix crash on boot: remove undefined _has_number_format references
+
 0.2.3
 =====
 - Use NumberFormat framework for decimal and thousands separators
 - Restructure settings, add balance denomination picker, theme-aware UI, wallet cache
 - Fix light mode background to match QR code white
-- Fix crash on boot: remove undefined _has_number_format references
 
 0.2.2
 =====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Use NumberFormat framework for decimal and thousands separators
 - Restructure settings, add balance denomination picker, theme-aware UI, wallet cache
 - Fix light mode background to match QR code white
+- Fix crash on boot: remove undefined _has_number_format references
 
 0.2.2
 =====

--- a/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
+++ b/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
@@ -3,10 +3,10 @@
 "publisher": "LightningPiggy Foundation",
 "short_description": "Display wallet that shows balance, transactions, receive QR code etc.",
 "long_description": "See https://www.LightningPiggy.com",
-"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.2.3_64x64.png",
-"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.2.3.mpk",
+"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.2.4_64x64.png",
+"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.2.4.mpk",
 "fullname": "com.lightningpiggy.displaywallet",
-"version": "0.2.3",
+"version": "0.2.4",
 "category": "finance",
 "activities": [
     {

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -565,11 +565,7 @@ class DisplayWallet(Activity):
         self.update_payments_label_font()
 
     def float_to_string(self, value, decimals):
-        if _has_number_format:
-            return NumberFormat.format_number(value, decimals)
-        # Fallback for firmware without NumberFormat
-        s = "{:.{}f}".format(value, decimals)
-        return s.rstrip("0").rstrip(".")
+        return NumberFormat.format_number(value, decimals)
 
     def display_balance(self, balance):
          self._last_balance = balance
@@ -577,7 +573,7 @@ class DisplayWallet(Activity):
          Payment.use_symbol = (denom == "symbol")
          if denom in ("sats", "symbol"):
              sats = int(round(balance))
-             formatted = NumberFormat.format_number(sats) if _has_number_format else str(sats)
+             formatted = NumberFormat.format_number(sats)
              if denom == "symbol":
                  balance_text = formatted
                  self.bitcoin_symbol.set_src(self._bitcoin_symbol_path())


### PR DESCRIPTION
## Problem
The app crashes on boot with `NameError: name '_has_number_format' isn't defined`, causing the splash screen to freeze permanently.

This was introduced when the merge of #18 changed the `NumberFormat` import from a `try/except` fallback to a direct import, but left two references to `_has_number_format` in `display_balance()` and `float_to_string()`.

## Error log
```
File "apps/.../displaywallet.py", line 518, in _load_and_display_cache
File "apps/.../displaywallet.py", line 580, in display_balance
NameError: name '_has_number_format' isn't defined
```

## Fix
Remove the `_has_number_format` checks since `NumberFormat` is now always imported directly.

## Merge checklist
- [x] CHANGELOG.md updated
- [x] Unit tests: `test_displaywallet_balance.py` added to MicroPythonOS tests (9 tests covering float_to_string and sats formatting)
- [x] No settings changes — no migration needed
- [x] Small focused diff — no non-functional changes mixed in

## Test plan
- [x] `./tests/unittest.sh tests/test_displaywallet_balance.py` — 9 tests pass
- [ ] Boot device — splash should dismiss after 2 seconds
- [ ] Balance displays correctly with number formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)