### PR TITLE
Add on-chain wallet type (xpub via Blockbook)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+0.5.0
+=====
+- Add on-chain wallet type: watch a Bitcoin xpub / ypub / zpub by polling a Blockbook indexer (Trezor's open-source explorer, https://github.com/trezor/blockbook). Server-side derivation means no BIP32 lib on the device. Defaults to Trezor's hosted instance at `btc1.trezor.io`; configurable to a self-hosted Blockbook (Umbrel / Start9 / BTCPay Server / Sparrow Server) for full privacy via the Settings → Wallet → Blockbook URL field
+- Receive QR auto-rotates to a fresh unused address after the displayed one has received a payment — preserves Bitcoin's "one address per receive" privacy convention. Avoids rotating mid-scan: the QR only changes after Blockbook reports the currently-displayed address has a transfer, not on every poll
+- Transactions list shows `"<amount> sats: Apr 16 confirmed"` / `"... pending"`; self-transfers (where every input AND every output belongs to the xpub) render as `"-<fee> sats: Apr 16 self-transfer"` so on-chain hopping looks like a fee-only loss instead of a misleading large net send
+- Poll cadence: 60 s while any tx is unconfirmed, 300 s when everything's confirmed — fast feedback during a receive without hammering the indexer the rest of the time
+- xpub is never written to logs or surfaced in error messages — leaking the xpub exposes the entire past + future derivation tree to anyone who reads it. The Blockbook URL passed to `DownloadManager.download_url` uses `redact_url=True` (MicroPythonOS 0.9.6+) so the framework also scrubs the xpub from its own request/response/exception log lines
+- Privacy note: any external indexer (mempool.space, Esplora, Blockbook, an Electrum server) learns your addresses and can link them. Doesn't affect custody — Lightning Piggy holds no keys — but does affect chain confidentiality. Point the Blockbook URL setting at your own node to eliminate it
+
 0.4.2
 =====
 - Remove unsupported lv.font_montserrat_40 (MicroPythonOS 0.9.6+)

--- a/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
+++ b/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
@@ -3,10 +3,10 @@
 "publisher": "LightningPiggy Foundation",
 "short_description": "Display wallet that shows balance, transactions, receive QR code etc.",
 "long_description": "See https://www.LightningPiggy.com",
-"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.4.2_64x64.png",
-"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.4.2.mpk",
+"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.5.0_64x64.png",
+"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.5.0.mpk",
 "fullname": "com.lightningpiggy.displaywallet",
-"version": "0.4.2",
+"version": "0.5.0",
 "category": "finance",
 "activities": [
     {

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -47,6 +47,7 @@ import wallet_cache
 # This prevents ImportError when switching wallet types after the app has started
 from lnbits_wallet import LNBitsWallet
 from nwc_wallet import NWCWallet
+from onchain_wallet import OnchainWallet
 
 
 def _apply_screen_theme(screen):
@@ -114,6 +115,8 @@ def _should_show_wallet_setting(setting):
         return False
     if wallet_type != "nwc" and setting["key"].startswith("nwc_"):
         return False
+    if wallet_type != "onchain" and setting["key"].startswith("onchain_"):
+        return False
     return True
 
 
@@ -124,7 +127,7 @@ class WalletSettingsActivity(SettingsActivity):
         self.prefs = extras.get("prefs")
         self.settings = [
             {"title": "Wallet Type", "key": "wallet_type", "ui": "radiobuttons",
-             "ui_options": [("LNBits", "lnbits"), ("Nostr Wallet Connect", "nwc")]},
+             "ui_options": [("LNBits", "lnbits"), ("Nostr Wallet Connect", "nwc"), ("On-chain (xpub)", "onchain")]},
             {"title": "LNBits URL", "key": "lnbits_url",
              "placeholder": "https://demo.lnpiggy.com", "should_show": _should_show_wallet_setting},
             {"title": "LNBits Read Key", "key": "lnbits_readkey",
@@ -135,6 +138,12 @@ class WalletSettingsActivity(SettingsActivity):
              "placeholder": "nostr+walletconnect://69effe7b...", "should_show": _should_show_wallet_setting},
             {"title": "Optional LN Address", "key": "nwc_static_receive_code",
              "placeholder": "Optional if present in NWC URL.", "should_show": _should_show_wallet_setting},
+            {"title": "xpub / ypub / zpub", "key": "onchain_xpub",
+             "placeholder": "zpub6rF...", "should_show": _should_show_wallet_setting},
+            {"title": "Blockbook URL", "key": "onchain_blockbook_url",
+             "placeholder": "https://btc1.trezor.io", "should_show": _should_show_wallet_setting},
+            {"title": "Optional Receive Address", "key": "onchain_static_receive_code",
+             "placeholder": "Auto-rotates if empty.", "should_show": _should_show_wallet_setting},
         ]
         screen = lv.obj()
         screen.set_style_pad_all(DisplayMetrics.pct_of_width(2), lv.PART.MAIN)
@@ -879,6 +888,12 @@ class DisplayWallet(Activity):
                     self.prefs.get_string("lnbits_readkey"))
         if wt == "nwc":
             return (wt, self.prefs.get_string("nwc_url"))
+        if wt == "onchain":
+            # Pointing the same xpub at a different Blockbook is a real
+            # config change — must trigger a wallet restart.
+            return (wt,
+                    self.prefs.get_string("onchain_xpub"),
+                    self.prefs.get_string("onchain_blockbook_url"))
         return (wt,)
 
     def onPause(self, main_screen):
@@ -1116,6 +1131,20 @@ class DisplayWallet(Activity):
                 self.redraw_static_receive_code_cb()
             except Exception as e:
                 self.error_cb(f"Couldn't initialize NWC Wallet because: {e}")
+                return
+        elif wallet_type == "onchain":
+            try:
+                blockbook_url = self.prefs.get_string("onchain_blockbook_url") or None
+                self.wallet = OnchainWallet(
+                    self.prefs.get_string("onchain_xpub"),
+                    blockbook_url=blockbook_url,
+                )
+                # Settings override (a user-supplied BIP21 URI / static address)
+                # wins; otherwise the wallet auto-rotates per-poll.
+                self.wallet.static_receive_code = self.prefs.get_string("onchain_static_receive_code")
+                self.redraw_static_receive_code_cb()
+            except Exception as e:
+                self.error_cb(f"Couldn't initialize On-chain wallet because: {e}")
                 return
         else:
             self.error_cb(f"No or unsupported wallet type configured: '{wallet_type}'")
@@ -1408,6 +1437,8 @@ class DisplayWallet(Activity):
             override = self.prefs.get_string("nwc_static_receive_code")
         elif wallet_type == "lnbits":
             override = self.prefs.get_string("lnbits_static_receive_code")
+        elif wallet_type == "onchain":
+            override = self.prefs.get_string("onchain_static_receive_code")
         # Next, the wallet's own discovered receive code (from backend / NWC lud16).
         wallet_code = self.wallet.static_receive_code if self.wallet else None
         # Pick the first non-empty source; fall through to whatever's already

--- a/com.lightningpiggy.displaywallet/assets/onchain_wallet.py
+++ b/com.lightningpiggy.displaywallet/assets/onchain_wallet.py
@@ -1,0 +1,254 @@
+import json
+import time
+
+from mpos import TaskManager, DownloadManager
+
+from wallet import Wallet
+from payment import Payment
+from unique_sorted_list import UniqueSortedList
+
+
+_MONTHS = ("Jan", "Feb", "Mar", "Apr", "May", "Jun",
+           "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
+
+def _try_int(v):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return 0
+
+
+class OnchainWallet(Wallet):
+    """On-chain Bitcoin wallet backed by a Blockbook instance.
+
+    Blockbook (https://github.com/trezor/blockbook) does server-side
+    derivation from the xpub/ypub/zpub and returns balance, transactions,
+    and derived addresses in a single call. The default points at Trezor's
+    hosted instance; privacy-conscious users can set a self-hosted Blockbook
+    URL (Umbrel, Start9, BTCPay Server, Sparrow Server, etc.) via the
+    onchain_blockbook_url setting.
+
+    Privacy note: whoever runs the Blockbook instance sees every address
+    derived from your xpub and can link them together. That's true of any
+    external indexer; funds custody is unaffected.
+    """
+
+    PAYMENTS_TO_SHOW = 6
+    PERIODIC_FETCH_SECONDS_UNCONFIRMED = 60   # while any tx is pending
+    PERIODIC_FETCH_SECONDS_CONFIRMED = 300    # when everything's confirmed
+    DEFAULT_BLOCKBOOK_URL = "https://btc1.trezor.io"
+    # Trezor's hosted Blockbook is Cloudflare-proxied; a browser UA avoids 403.
+    _USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64) "
+                   "AppleWebKit/537.36 (KHTML, like Gecko) "
+                   "Chrome/122 Safari/537.36")
+
+    def __init__(self, xpub, blockbook_url=None):
+        super().__init__()
+        if not xpub:
+            raise ValueError('xpub is not set.')
+        xpub = xpub.strip()
+        if xpub[:4] not in ("xpub", "ypub", "zpub", "tpub", "upub", "vpub"):
+            raise ValueError('xpub must start with xpub/ypub/zpub (or testnet variants)')
+        self.xpub = xpub
+        self.blockbook_url = (blockbook_url or self.DEFAULT_BLOCKBOOK_URL).rstrip('/')
+        # Cache slot — DisplayWallet.went_online() stamps creds/qr fingerprints
+        # after construction (same pattern as LNBitsWallet / NWCWallet).
+        self.slot_key = "onchain"
+        self._any_unconfirmed = True  # first poll uses fast cadence
+        # Tracks whether the currently-displayed receive address has been used
+        # yet, so we know when to rotate to the next unused index. Initially
+        # None — first successful fetch will pick one.
+        self._displayed_receive_addr = None
+
+    def _format_date(self, epoch_time):
+        """Format epoch time as 'Apr 16' (month + day)."""
+        try:
+            t = time.localtime(epoch_time)
+            return "{} {}".format(_MONTHS[t[1] - 1], t[2])
+        except Exception:
+            return ""
+
+    def _parse_transactions(self, transactions):
+        """Parse Blockbook transactions into a UniqueSortedList of Payments.
+
+        Blockbook marks inputs/outputs belonging to our xpub with
+        `isOwn: true`, so we don't need to track derived addresses ourselves.
+        Returns (payments, any_unconfirmed).
+        """
+        payments = UniqueSortedList()
+        any_unconfirmed = False
+
+        for tx in transactions or []:
+            confirmations = tx.get("confirmations", 0) or 0
+            confirmed = confirmations > 0
+            if not confirmed:
+                any_unconfirmed = True
+
+            sent = 0
+            all_inputs_ours = bool(tx.get("vin"))
+            for vin in tx.get("vin", []):
+                if vin.get("isOwn"):
+                    sent += _try_int(vin.get("value", "0"))
+                else:
+                    all_inputs_ours = False
+
+            received = 0
+            all_outputs_ours = bool(tx.get("vout"))
+            for vout in tx.get("vout", []):
+                if vout.get("isOwn"):
+                    received += _try_int(vout.get("value", "0"))
+                else:
+                    all_outputs_ours = False
+
+            net = received - sent
+            epoch_time = tx.get("blockTime") or int(time.time())
+            date_str = self._format_date(epoch_time)
+            status_str = "confirmed" if confirmed else "pending"
+
+            if all_inputs_ours and all_outputs_ours:
+                # All inputs + outputs ours — classic self-transfer, fee-only loss.
+                fee = _try_int(tx.get("fees", "0"))
+                comment = "{} self-transfer".format(date_str).strip()
+                payments.add(Payment(epoch_time, -fee, comment))
+            else:
+                comment = "{} {}".format(date_str, status_str).strip()
+                payments.add(Payment(epoch_time, net, comment))
+
+        return payments, any_unconfirmed
+
+    def _pick_unused_receive_address(self, tokens):
+        """Return the lowest-index unused external receive address, or None.
+
+        Blockbook tokens carry a `path` like `m/84'/0'/0'/0/3`. The
+        second-to-last segment is the chain (0 = external / receive,
+        1 = change). We pick the lowest-index entry with transfers == 0.
+        """
+        best_idx = None
+        best_addr = None
+        for t in tokens or []:
+            path = t.get("path") or ""
+            parts = path.split("/")
+            if len(parts) < 2:
+                continue
+            if parts[-2] != "0":  # must be external (receive) chain
+                continue
+            if (t.get("transfers") or 0) != 0:
+                continue
+            try:
+                idx = int(parts[-1])
+            except ValueError:
+                continue
+            if best_idx is None or idx < best_idx:
+                best_idx = idx
+                best_addr = t.get("name")
+        return best_addr
+
+    def _displayed_address_has_been_used(self, tokens, current_addr):
+        """True if the currently-displayed receive address now has a transfer.
+
+        Used to rotate the QR to the next unused address right after a
+        payment lands on the displayed one, without rotating mid-scan
+        when the address is still fresh.
+        """
+        if not current_addr:
+            return False
+        for t in tokens or []:
+            if t.get("name") == current_addr:
+                return (t.get("transfers") or 0) > 0
+        # Not in the response (gap-limit drift, etc.) → assume still fresh.
+        return False
+
+    async def fetch_balance_and_payments(self):
+        """Single Blockbook call populates balance, payments, and receive code."""
+        url = "{}/api/v2/xpub/{}?details=txs&tokens=derived".format(
+            self.blockbook_url, self.xpub)
+        # Don't log the full URL: it contains the xpub, which would leak the
+        # user's entire derivation tree (all past/future addresses) if logs
+        # are ever shared for debugging.
+        print("OnchainWallet: fetching from {}".format(self.blockbook_url))
+        try:
+            # redact_url=True (MicroPythonOS 0.9.6+) tells the framework to
+            # log only `scheme://host/...REDACTED...` instead of the full
+            # URL, suppress its response-headers dump, and scrub the URL
+            # from any aiohttp exception message that bubbles up. Belt-and-
+            # braces for the print() above which already hides the xpub.
+            response_bytes = await DownloadManager.download_url(
+                url, headers={"User-Agent": self._USER_AGENT},
+                redact_url=True)
+        except Exception as e:
+            # Scrub xpub from error message for the same reason.
+            raise RuntimeError(
+                "fetch_balance: GET to {} failed: {}".format(self.blockbook_url, e))
+
+        try:
+            response = json.loads(response_bytes.decode("utf-8"))
+        except Exception as e:
+            raise RuntimeError("Could not parse Blockbook response as JSON: {}".format(e))
+
+        # Balance: confirmed + mempool (Blockbook returns strings; unconfirmed may be negative)
+        balance = (_try_int(response.get("balance", "0"))
+                   + _try_int(response.get("unconfirmedBalance", "0")))
+        self.handle_new_balance(balance, fetchPaymentsIfChanged=False)
+
+        # Payments
+        payments, any_unconfirmed = self._parse_transactions(response.get("transactions"))
+        self._any_unconfirmed = any_unconfirmed or (response.get("unconfirmedTxs") or 0) > 0
+        if len(payments) > 0:
+            self.handle_new_payments(payments)
+
+        # Receive address rotation — skip entirely if user has pinned one in
+        # Settings (handle_new_static_receive_code dedups by string so the
+        # settings-supplied value won't change). Otherwise:
+        #
+        #   - On first poll, the wallet has no displayed address yet → pick one.
+        #   - On subsequent polls, only rotate when Blockbook reports the
+        #     currently-displayed address has received its first transfer.
+        #     This avoids rotating the QR mid-scan when a payer is still
+        #     looking at it.
+        tokens = response.get("tokens")
+        if not self._displayed_receive_addr:
+            # First time → pick the lowest unused index.
+            picked = self._pick_unused_receive_address(tokens)
+            if picked:
+                self._displayed_receive_addr = picked
+                self.handle_new_static_receive_code("bitcoin:" + picked)
+        elif self._displayed_address_has_been_used(tokens, self._displayed_receive_addr):
+            # Displayed address received a payment → rotate to next unused.
+            picked = self._pick_unused_receive_address(tokens)
+            if picked and picked != self._displayed_receive_addr:
+                self._displayed_receive_addr = picked
+                self.handle_new_static_receive_code("bitcoin:" + picked)
+
+        # Heartbeat for the stale-data indicator — fires every successful
+        # fetch even when nothing changed (a healthy quiet wallet would
+        # otherwise look identical to an offline one).
+        self.notify_poll_success()
+
+    async def fetch_balance(self):
+        """Alias for fetch_balance_and_payments (base class compatibility)."""
+        await self.fetch_balance_and_payments()
+
+    async def fetch_payments(self):
+        """No-op — payments are fetched alongside the balance."""
+        pass
+
+    async def async_wallet_manager_task(self):
+        while self.keep_running:
+            try:
+                await self.fetch_balance_and_payments()
+            except Exception as e:
+                print("WARNING: OnchainWallet got exception: {}".format(e))
+                import sys
+                sys.print_exception(e)
+                self.handle_error(e)
+
+            interval = (self.PERIODIC_FETCH_SECONDS_UNCONFIRMED
+                        if self._any_unconfirmed
+                        else self.PERIODIC_FETCH_SECONDS_CONFIRMED)
+            print("Sleeping {}s before next on-chain fetch...".format(interval))
+            for _ in range(interval * 10):
+                await TaskManager.sleep(0.1)
+                if not self.keep_running:
+                    break
+        print("OnchainWallet main() stopping...")

--- a/com.lightningpiggy.displaywallet/assets/wallet.py
+++ b/com.lightningpiggy.displaywallet/assets/wallet.py
@@ -49,6 +49,8 @@ class Wallet:
             return "LNBitsWallet"
         elif isinstance(self, NWCWallet):
             return "NWCWallet"
+        elif isinstance(self, OnchainWallet):
+            return "OnchainWallet"
 
     def notify_poll_success(self):
         """Subclasses call this after any successful fetch (balance OR

--- a/com.lightningpiggy.displaywallet/assets/wallet_cache.py
+++ b/com.lightningpiggy.displaywallet/assets/wallet_cache.py
@@ -68,6 +68,16 @@ def compute_fingerprints(wallet_type, prefs):
         creds_fp = _fingerprint("nwc", nwc_url)
         qr_fp = _fingerprint("nwc", nwc_url, override)
         return creds_fp, qr_fp
+    if wallet_type == "onchain":
+        xpub = prefs.get_string("onchain_xpub") or ""
+        blockbook_url = prefs.get_string("onchain_blockbook_url") or ""
+        override = prefs.get_string("onchain_static_receive_code") or ""
+        # Both xpub and the indexer URL participate: pointing the same
+        # xpub at a different Blockbook is a valid config change and must
+        # invalidate cached balance + payments.
+        creds_fp = _fingerprint("onchain", xpub, blockbook_url)
+        qr_fp = _fingerprint("onchain", xpub, blockbook_url, override)
+        return creds_fp, qr_fp
     return None, None
 
 

--- a/tests/test_onchain_wallet.py
+++ b/tests/test_onchain_wallet.py
@@ -1,0 +1,206 @@
+"""
+Unit tests for the on-chain wallet type in the Lightning Piggy app.
+
+Targets LightningPiggyApp PR #25 (on-chain wallet via Blockbook).
+
+The vendored tests/unittest.sh auto-injects the app's assets/ dir into
+sys.path, so these imports work without any further path manipulation.
+
+Usage (from the LightningPiggyApp repo root):
+    Desktop: bash tests/unittest.sh tests/test_onchain_wallet.py
+    Device:  bash tests/unittest.sh tests/test_onchain_wallet.py --ondevice
+"""
+
+import unittest
+
+try:
+    from onchain_wallet import OnchainWallet
+    _HAVE_ONCHAIN = True
+except ImportError:
+    _HAVE_ONCHAIN = False
+
+
+@unittest.skipUnless(_HAVE_ONCHAIN, "onchain_wallet.py not installed (feature not landed yet)")
+class TestOnchainWalletConstructor(unittest.TestCase):
+
+    def test_rejects_empty_xpub(self):
+        with self.assertRaises(ValueError):
+            OnchainWallet("")
+
+    def test_rejects_bad_prefix(self):
+        with self.assertRaises(ValueError):
+            OnchainWallet("foobarbaz")
+
+    def test_accepts_xpub_prefix(self):
+        w = OnchainWallet("xpub1234example")
+        self.assertEqual(w.xpub, "xpub1234example")
+
+    def test_accepts_zpub_prefix(self):
+        w = OnchainWallet("zpub1234example")
+        self.assertEqual(w.xpub, "zpub1234example")
+
+    def test_trims_blockbook_trailing_slash(self):
+        w = OnchainWallet("zpub1234example", blockbook_url="https://example.com/")
+        self.assertEqual(w.blockbook_url, "https://example.com")
+
+    def test_blockbook_url_default_when_none(self):
+        w = OnchainWallet("zpub1234example")
+        self.assertEqual(w.blockbook_url, OnchainWallet.DEFAULT_BLOCKBOOK_URL)
+
+    def test_blockbook_url_empty_falls_back_to_default(self):
+        # An empty string URL pref should behave the same as None.
+        w = OnchainWallet("zpub1234example", blockbook_url=None)
+        self.assertEqual(w.blockbook_url, OnchainWallet.DEFAULT_BLOCKBOOK_URL)
+
+    def test_sets_cache_slot_key(self):
+        # Required by the post-#33 Wallet contract — handle_new_* routes
+        # writes through wallet_cache.save_slot(slot_key=...).
+        w = OnchainWallet("zpub1234example")
+        self.assertEqual(w.slot_key, "onchain")
+
+
+@unittest.skipUnless(_HAVE_ONCHAIN, "onchain_wallet.py not installed")
+class TestOnchainWalletParseTransactions(unittest.TestCase):
+
+    def setUp(self):
+        self.w = OnchainWallet("zpub1234example")
+
+    def test_confirmed_incoming_tx(self):
+        txs = [{
+            "txid": "abc", "confirmations": 5, "blockTime": 1775838000,
+            "vin": [{"isOwn": False, "value": "10000"}],
+            "vout": [{"isOwn": True, "value": "6884"}, {"isOwn": False, "value": "3000"}],
+        }]
+        payments, any_unconfirmed = self.w._parse_transactions(txs)
+        self.assertEqual(len(payments), 1)
+        p = list(payments)[0]
+        self.assertEqual(p.amount_sats, 6884)
+        self.assertIn("confirmed", p.comment)
+        self.assertFalse(any_unconfirmed)
+
+    def test_unconfirmed_tx_flagged(self):
+        txs = [{
+            "txid": "pending", "confirmations": 0, "blockTime": 0,
+            "vin": [{"isOwn": False, "value": "10000"}],
+            "vout": [{"isOwn": True, "value": "5000"}],
+        }]
+        _payments, any_unconfirmed = self.w._parse_transactions(txs)
+        self.assertTrue(any_unconfirmed)
+
+    def test_self_transfer_is_fee_only(self):
+        # All inputs + all outputs marked isOwn → classic self-transfer: the
+        # wallet loses only the network fee.
+        txs = [{
+            "txid": "self", "confirmations": 10, "blockTime": 1775838000, "fees": "500",
+            "vin": [{"isOwn": True, "value": "50500"}],
+            "vout": [{"isOwn": True, "value": "50000"}],
+        }]
+        payments, _unc = self.w._parse_transactions(txs)
+        p = list(payments)[0]
+        self.assertEqual(p.amount_sats, -500)
+        self.assertIn("self-transfer", p.comment)
+
+    def test_outgoing_tx_uses_net_amount(self):
+        # Our input 20000, our output 15000 (change) → net -5000 sent.
+        txs = [{
+            "txid": "out", "confirmations": 3, "blockTime": 1775838000, "fees": "200",
+            "vin": [{"isOwn": True, "value": "20000"}],
+            "vout": [
+                {"isOwn": True, "value": "15000"},      # change back to us
+                {"isOwn": False, "value": "4800"},      # paid out to someone else
+            ],
+        }]
+        payments, _unc = self.w._parse_transactions(txs)
+        p = list(payments)[0]
+        # Net = 15000 - 20000 = -5000 (it goes through the non-self-transfer branch
+        # because not all vout is isOwn).
+        self.assertEqual(p.amount_sats, -5000)
+
+    def test_empty_transactions(self):
+        payments, any_unconfirmed = self.w._parse_transactions([])
+        self.assertEqual(len(payments), 0)
+        self.assertFalse(any_unconfirmed)
+
+    def test_none_transactions(self):
+        # Response may legitimately have no "transactions" key.
+        payments, any_unconfirmed = self.w._parse_transactions(None)
+        self.assertEqual(len(payments), 0)
+        self.assertFalse(any_unconfirmed)
+
+
+@unittest.skipUnless(_HAVE_ONCHAIN, "onchain_wallet.py not installed")
+class TestOnchainWalletPickUnusedAddress(unittest.TestCase):
+
+    def setUp(self):
+        self.w = OnchainWallet("zpub1234example")
+
+    def test_picks_first_unused_external(self):
+        tokens = [
+            {"name": "bc1qused1", "path": "m/84'/0'/0'/0/0", "transfers": 3},
+            {"name": "bc1qfirst", "path": "m/84'/0'/0'/0/5", "transfers": 0},
+            {"name": "bc1qsecond", "path": "m/84'/0'/0'/0/6", "transfers": 0},
+        ]
+        # Returns bare address (no "bitcoin:" prefix); the caller in
+        # fetch_balance_and_payments prepends the BIP21 scheme.
+        self.assertEqual(self.w._pick_unused_receive_address(tokens), "bc1qfirst")
+
+    def test_skips_change_chain(self):
+        tokens = [
+            {"name": "bc1qchange", "path": "m/84'/0'/0'/1/0", "transfers": 0},  # internal/change
+            {"name": "bc1qexternal", "path": "m/84'/0'/0'/0/0", "transfers": 0},
+        ]
+        self.assertEqual(self.w._pick_unused_receive_address(tokens), "bc1qexternal")
+
+    def test_skips_used_addresses(self):
+        tokens = [
+            {"name": "bc1qused1", "path": "m/84'/0'/0'/0/0", "transfers": 7},
+            {"name": "bc1qused2", "path": "m/84'/0'/0'/0/1", "transfers": 1},
+        ]
+        self.assertIsNone(self.w._pick_unused_receive_address(tokens))
+
+    def test_none_when_no_tokens(self):
+        self.assertIsNone(self.w._pick_unused_receive_address([]))
+        self.assertIsNone(self.w._pick_unused_receive_address(None))
+
+    def test_returns_lowest_index_unused(self):
+        # Three unused external addresses — the one at index 1 must win
+        # regardless of list order, because it has the lowest derivation index.
+        tokens = [
+            {"name": "bc1qthird", "path": "m/84'/0'/0'/0/3", "transfers": 0},
+            {"name": "bc1qfirst", "path": "m/84'/0'/0'/0/1", "transfers": 0},
+            {"name": "bc1qsecond", "path": "m/84'/0'/0'/0/2", "transfers": 0},
+        ]
+        self.assertEqual(self.w._pick_unused_receive_address(tokens), "bc1qfirst")
+
+
+@unittest.skipUnless(_HAVE_ONCHAIN, "onchain_wallet.py not installed")
+class TestOnchainWalletAddressRotation(unittest.TestCase):
+    """The displayed receive QR should rotate to a fresh address only AFTER the
+    previously-shown address has actually received a payment — not on every
+    poll, which would change the QR while a payer is mid-scan."""
+
+    def setUp(self):
+        self.w = OnchainWallet("zpub1234example")
+
+    def test_unused_address_initially_reports_not_used(self):
+        tokens = [{"name": "bc1qa", "path": "m/84'/0'/0'/0/0", "transfers": 0}]
+        self.assertFalse(self.w._displayed_address_has_been_used(tokens, "bc1qa"))
+
+    def test_address_with_transfers_reports_used(self):
+        tokens = [{"name": "bc1qa", "path": "m/84'/0'/0'/0/0", "transfers": 1}]
+        self.assertTrue(self.w._displayed_address_has_been_used(tokens, "bc1qa"))
+
+    def test_missing_address_treated_as_still_fresh(self):
+        # Address not present in the response (e.g. gap-limit drift) →
+        # don't rotate. Prevents spurious QR flips on response variance.
+        tokens = [{"name": "bc1qother", "path": "m/84'/0'/0'/0/1", "transfers": 0}]
+        self.assertFalse(self.w._displayed_address_has_been_used(tokens, "bc1qa"))
+
+    def test_none_displayed_address_reports_not_used(self):
+        # No address picked yet (first poll) — never report "used" in this
+        # state, since the rotate-on-use branch shouldn't fire.
+        self.assertFalse(self.w._displayed_address_has_been_used([], None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a third wallet type alongside LNBits and Nostr Wallet Connect: an on-chain watcher that tracks a Bitcoin xpub (or ypub/zpub, plus testnet variants) via [Blockbook](https://github.com/trezor/blockbook). Users with on-chain savings can now display their balance, recent transactions, and an unused receive address as a QR code — without needing to run a Lightning node.

- Balance = `balance + unconfirmedBalance` from Blockbook (sum of all derived addresses, confirmed + mempool).
- Transactions use Blockbook's `isOwn` flags on `vin`/`vout` — so we compute net sats without tracking derived addresses client-side. Rendered as e.g. `6884 sats: Apr 10 confirmed` or `-300 sats: Apr 17 pending`.
- Self-transfer detection: all `vin` marked `isOwn` AND all `vout` marked `isOwn` → show as fee-only loss (`-fee sats: Apr 16 self-transfer`).
- Receive QR: lowest-index unused external address (path `m/.../0/N` with `transfers == 0`) from Blockbook's `tokens` array, rendered as a `bitcoin:` BIP21 URI. Users can override via `Optional Receive Address` in settings.
- Polling is adaptive: every 60s while any tx is unconfirmed, then 5min once everything is confirmed.
- Invalid/missing xpub or bad Blockbook URL surface via the normal error UI (`Couldn't initialize On-chain wallet because: …`) and preserve cached data on-screen.

## Why Blockbook (and not mempool.space)?
We originally planned to use `mempool.space/api/v1/wallet/{xpub}`, but verified end-to-end that the public mempool.space only serves **pre-registered** wallets via that endpoint — arbitrary xpubs return `404 "No such wallet"`. Likewise, blockstream.info's Esplora REST API is single-address-only (no xpub endpoint), and blockchain.info only supports legacy BIP44 xpubs (not zpub / native SegWit).

Blockbook is Trezor's open-source explorer, also shipped with Umbrel, Start9, BTCPay Server, Sparrow Server, and Nunchuk — so a widely deployed standard. The default `https://btc1.trezor.io` is Cloudflare-proxied and needs a browser `User-Agent` header to avoid 403s; `DownloadManager.download_url(headers=…)` supports that out of the box.

## Privacy notes
Using the public `https://btc1.trezor.io` means Trezor can see every address derived from the xpub and link them together. This is unavoidable with any external indexer. Privacy-conscious users can run their own Blockbook (Umbrel/Start9/BTCPay/Sparrow Server all ship it) and point the `Blockbook URL` setting at it — the URL is fully configurable.

## Changes
| File | Change |
|---|---|
| `com.lightningpiggy.displaywallet/assets/onchain_wallet.py` | NEW — `OnchainWallet(Wallet)` polling class backed by Blockbook |
| `com.lightningpiggy.displaywallet/assets/displaywallet.py` | Import, settings UI (`onchain_xpub`, `onchain_blockbook_url`, `onchain_static_receive_code`), `went_online` branch, `redraw_static_receive_code_cb` branch |
| `com.lightningpiggy.displaywallet/assets/wallet.py` | `__str__` branch for `OnchainWallet` |
| `com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON` | Version 0.2.6 → 0.2.7 |
| `CHANGELOG.md` | New 0.2.7 section |

## Test plan
- [x] Desktop build: `OnchainWallet('…')` instantiates, rejects empty and bad-prefix inputs, trims trailing `/` on Blockbook URL
- [x] Desktop build: `_parse_transactions(fixture_from_btc1.trezor.io)` produces correct Payment (`6884 sats: Apr 10 confirmed`), marks pending txs as unconfirmed, picks first unused external address as `bitcoin:` receive URI
- [x] Desktop build: end-to-end run against `btc1.trezor.io` — balance (₿6,884), payment list, and receive QR all render; adaptive polling switches to 300s after confirmation
- [ ] Device build (pending)
- [ ] Regression: existing LNBits + NWC flows unchanged
- [ ] Self-hosted Blockbook instance (e.g. Umbrel) for privacy verification