### PR TITLE
Add Light/Dark theme toggle in Customise settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-1.0.0
+0.3.0
 =====
 - Light/Dark theme toggle in Customise settings — app-local override that doesn't touch the OS-level theme; other apps and the launcher keep the user's OS preference
 - Dark mode uses pure black (#000) for the main display and settings screens (previously a dark charcoal); keeps the screen consistent with the QR code backdrop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.2.7
+=====
+- Light/Dark theme toggle in Customise settings — app-local override that doesn't touch the OS-level theme; other apps and the launcher keep the user's OS preference
+
 0.2.6
 =====
 - Use native ₿ font glyph for balance and transaction amounts (replaces PNG images)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.2.7
+1.0.0
 =====
 - Light/Dark theme toggle in Customise settings — app-local override that doesn't touch the OS-level theme; other apps and the launcher keep the user's OS preference
 - Dark mode uses pure black (#000) for the main display and settings screens (previously a dark charcoal); keeps the screen consistent with the QR code backdrop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.2.7
 =====
 - Light/Dark theme toggle in Customise settings — app-local override that doesn't touch the OS-level theme; other apps and the launcher keep the user's OS preference
+- Dark mode uses pure black (#000) for the main display and settings screens (previously a dark charcoal); keeps the screen consistent with the QR code backdrop
 
 0.2.6
 =====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 0.3.0
 =====
 - Light/Dark theme toggle in Customise settings — app-local override that doesn't touch the OS-level theme; other apps and the launcher keep the user's OS preference
-- Dark mode uses pure black (#000) for the main display and settings screens (previously a dark charcoal); keeps the screen consistent with the QR code backdrop
+- Dark mode uses pure black (#000) for the main display, settings screens, and the fullscreen QR view (previously a dark charcoal); keeps all surfaces consistent with the QR code backdrop
 
 0.2.6
 =====

--- a/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
+++ b/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
@@ -3,10 +3,10 @@
 "publisher": "LightningPiggy Foundation",
 "short_description": "Display wallet that shows balance, transactions, receive QR code etc.",
 "long_description": "See https://www.LightningPiggy.com",
-"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.2.7_64x64.png",
-"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.2.7.mpk",
+"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_1.0.0_64x64.png",
+"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_1.0.0.mpk",
 "fullname": "com.lightningpiggy.displaywallet",
-"version": "0.2.7",
+"version": "1.0.0",
 "category": "finance",
 "activities": [
     {

--- a/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
+++ b/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
@@ -3,10 +3,10 @@
 "publisher": "LightningPiggy Foundation",
 "short_description": "Display wallet that shows balance, transactions, receive QR code etc.",
 "long_description": "See https://www.LightningPiggy.com",
-"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_1.0.0_64x64.png",
-"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_1.0.0.mpk",
+"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.3.0_64x64.png",
+"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.3.0.mpk",
 "fullname": "com.lightningpiggy.displaywallet",
-"version": "1.0.0",
+"version": "0.3.0",
 "category": "finance",
 "activities": [
     {

--- a/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
+++ b/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
@@ -3,10 +3,10 @@
 "publisher": "LightningPiggy Foundation",
 "short_description": "Display wallet that shows balance, transactions, receive QR code etc.",
 "long_description": "See https://www.LightningPiggy.com",
-"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.2.6_64x64.png",
-"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.2.6.mpk",
+"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.2.7_64x64.png",
+"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.2.7.mpk",
 "fullname": "com.lightningpiggy.displaywallet",
-"version": "0.2.6",
+"version": "0.2.7",
 "category": "finance",
 "activities": [
     {

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -122,9 +122,11 @@ class CustomiseSettingsActivity(SettingsActivity):
         callbacks = setting.get("_callbacks") or {}
         # Theme row shows the effective mode. If the app has a local override
         # set, use that; otherwise show whatever the OS theme resolves to.
+        # (Using a literal map because MicroPython's str lacks .capitalize().)
         override = self.prefs.get_string("theme_override", "")
-        if override in ("light", "dark"):
-            theme_label = override.capitalize()
+        theme_display = {"light": "Light", "dark": "Dark"}
+        if override in theme_display:
+            theme_label = theme_display[override]
         else:
             theme_label = "Light" if AppearanceManager.is_light_mode() else "Dark"
         self.settings = [
@@ -164,7 +166,7 @@ class CustomiseSettingsActivity(SettingsActivity):
             # any chance to disturb the widget state.
             value_label = setting.get("value_label")
             if value_label:
-                value_label.set_text(new_value.capitalize())
+                value_label.set_text({"light": "Light", "dark": "Dark"}[new_value])
             # Defer theme reinit to the next LVGL tick so the current click
             # event finishes cleanly before LVGL re-themes everything. Calling
             # lv.theme_default_init() from inside an event handler causes the
@@ -403,11 +405,11 @@ class DisplayWallet(Activity):
         settings_button.set_style_border_width(0, lv.PART.MAIN)
         settings_button.set_scrollbar_mode(lv.SCROLLBAR_MODE.OFF)
         settings_button.add_event_cb(self.settings_button_tap,lv.EVENT.CLICKED,None)
-        settings_icon = lv.label(settings_button)
-        settings_icon.set_text(lv.SYMBOL.SETTINGS)
-        settings_icon.set_style_text_font(lv.font_montserrat_18, lv.PART.MAIN)
-        settings_icon.set_style_text_color(self._icon_color(), lv.PART.MAIN)
-        settings_icon.center()
+        self.settings_icon = lv.label(settings_button)
+        self.settings_icon.set_text(lv.SYMBOL.SETTINGS)
+        self.settings_icon.set_style_text_font(lv.font_montserrat_18, lv.PART.MAIN)
+        self.settings_icon.set_style_text_color(self._icon_color(), lv.PART.MAIN)
+        self.settings_icon.center()
         focusgroup = lv.group_get_default()
         if focusgroup:
             focusgroup.add_obj(settings_button)
@@ -696,7 +698,7 @@ class DisplayWallet(Activity):
         return (lv.color_black(), lv.color_white())
 
     def _apply_qr_theme(self):
-        """Reapply theme-dependent styles (screen bg, QR colors) when returning from settings."""
+        """Reapply theme-dependent styles (screen bg, QR colors, icon tints)."""
         # Screen background follows light/dark mode — otherwise the hardcoded
         # bg from onCreate lingers after a theme toggle.
         if AppearanceManager.is_light_mode():
@@ -709,6 +711,9 @@ class DisplayWallet(Activity):
         self.receive_qr.set_style_border_color(light, lv.PART.MAIN)
         if self.receive_qr_data:
             self.receive_qr.update(self.receive_qr_data, len(self.receive_qr_data))
+        # Settings-cog icon colour tracks the theme (white in dark mode, black in light).
+        if hasattr(self, 'settings_icon'):
+            self.settings_icon.set_style_text_color(self._icon_color(), lv.PART.MAIN)
         # Re-render balance in case denomination setting changed
         if hasattr(self, '_last_balance'):
             self.display_balance(self._last_balance)

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -160,11 +160,17 @@ class CustomiseSettingsActivity(SettingsActivity):
             editor = self.prefs.edit()
             editor.put_string("theme_override", new_value)
             editor.commit()
-            # Apply immediately via the synthesised prefs (no OS disk writes)
-            _apply_displaywallet_theme(self.prefs)
+            # Update the label synchronously FIRST, before the theme reinit has
+            # any chance to disturb the widget state.
             value_label = setting.get("value_label")
             if value_label:
                 value_label.set_text(new_value.capitalize())
+            # Defer theme reinit to the next LVGL tick so the current click
+            # event finishes cleanly before LVGL re-themes everything. Calling
+            # lv.theme_default_init() from inside an event handler causes the
+            # setting row's click handlers to misbehave on subsequent taps.
+            prefs = self.prefs
+            lv.async_call(lambda *args: _apply_displaywallet_theme(prefs), None)
         else:
             super().startSettingActivity(setting)
 

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -526,6 +526,12 @@ class DisplayWallet(Activity):
         # Ensure the app's effective theme (local override or OS) is applied.
         # This never writes to OS prefs — see _apply_displaywallet_theme.
         _apply_displaywallet_theme(self.prefs)
+        # Re-apply theme-dependent styles (screen bg, QR colors) right away —
+        # onCreate set these based on is_light_mode at construction time, before
+        # our app-local override had a chance to flip it. On first launch after
+        # a theme override is active, the onCreate bg colour is wrong; this
+        # corrects it before the splash even runs.
+        self._apply_qr_theme()
         cm = ConnectivityManager.get()
         cm.register_callback(self.network_changed)
         if not self.splash_shown:
@@ -536,9 +542,6 @@ class DisplayWallet(Activity):
         else:
             # Returning from settings or other activity
             self._update_hero_image()
-            # Re-apply theme-dependent styles every time we return — the user
-            # may have toggled Light/Dark in the Customise settings.
-            self._apply_qr_theme()
             if self.wallet and self.wallet.is_running():
                 # Wallet already running — just redisplay, no re-fetch
                 if hasattr(self, '_last_balance'):

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -19,8 +19,22 @@ from lnbits_wallet import LNBitsWallet
 from nwc_wallet import NWCWallet
 
 
+def _apply_screen_theme(screen):
+    """Force an explicit screen bg that matches the app's main display colour —
+    pure black in dark mode, pure white in light mode. Must set BOTH directions:
+    once the explicit style is set it overrides LVGL's default-theme bg, so a
+    dark→light toggle would leave a lingering black bg if we only set black."""
+    if AppearanceManager.is_light_mode():
+        screen.set_style_bg_color(lv.color_white(), lv.PART.MAIN)
+    else:
+        screen.set_style_bg_color(lv.color_black(), lv.PART.MAIN)
+
+
 def _add_floating_back_button(screen, finish_callback):
-    """Add a floating back-to-display button at bottom-right of a settings screen."""
+    """Add a floating back-to-display button at bottom-right of a settings screen.
+    Also tints the screen bg to match the active theme (pure black in dark mode,
+    pure white in light mode) for consistency with the main wallet display."""
+    _apply_screen_theme(screen)
     back_btn = lv.obj(screen)
     back_btn.set_size(50, 50)
     back_btn.align(lv.ALIGN.BOTTOM_RIGHT, 0, 0)
@@ -171,8 +185,14 @@ class CustomiseSettingsActivity(SettingsActivity):
             # event finishes cleanly before LVGL re-themes everything. Calling
             # lv.theme_default_init() from inside an event handler causes the
             # setting row's click handlers to misbehave on subsequent taps.
+            # Also re-tint the active screen's bg — the explicit style set by
+            # _apply_screen_theme doesn't change automatically when the theme
+            # reinits, so a dark→light flip would leave the old bg behind.
             prefs = self.prefs
-            lv.async_call(lambda *args: _apply_displaywallet_theme(prefs), None)
+            def _retheme(*args):
+                _apply_displaywallet_theme(prefs)
+                _apply_screen_theme(lv.screen_active())
+            lv.async_call(_retheme, None)
         else:
             super().startSettingActivity(setting)
 
@@ -223,6 +243,7 @@ class DenominationSettingsActivity(Activity):
         screen.set_style_pad_all(DisplayMetrics.pct_of_width(2), lv.PART.MAIN)
         screen.set_flex_flow(lv.FLEX_FLOW.COLUMN)
         screen.set_style_border_width(0, lv.PART.MAIN)
+        _apply_screen_theme(screen)
 
         title = lv.label(screen)
         title.set_text("Balance Denomination")
@@ -354,7 +375,7 @@ class DisplayWallet(Activity):
         self.prefs = SharedPreferences("com.lightningpiggy.displaywallet")
         self.main_screen = lv.obj()
         if not AppearanceManager.is_light_mode():
-            self.main_screen.set_style_bg_color(lv.color_hex(0x15171A), lv.PART.MAIN)
+            self.main_screen.set_style_bg_color(lv.color_black(), lv.PART.MAIN)
         else:
             self.main_screen.set_style_bg_color(lv.color_white(), lv.PART.MAIN)
         self.main_screen.set_style_pad_all(0, lv.PART.MAIN)
@@ -694,7 +715,7 @@ class DisplayWallet(Activity):
     def _qr_colors(self):
         """Return (dark_color, light_color) tuple based on current theme."""
         if not AppearanceManager.is_light_mode():
-            return (lv.color_white(), lv.color_hex(0x15171A))
+            return (lv.color_white(), lv.color_black())
         return (lv.color_black(), lv.color_white())
 
     def _apply_qr_theme(self):
@@ -704,7 +725,7 @@ class DisplayWallet(Activity):
         if AppearanceManager.is_light_mode():
             self.main_screen.set_style_bg_color(lv.color_white(), lv.PART.MAIN)
         else:
-            self.main_screen.set_style_bg_color(lv.color_hex(0x15171A), lv.PART.MAIN)
+            self.main_screen.set_style_bg_color(lv.color_black(), lv.PART.MAIN)
         dark, light = self._qr_colors()
         self.receive_qr.set_dark_color(dark)
         self.receive_qr.set_light_color(light)

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -434,15 +434,6 @@ class DisplayWallet(Activity):
         focusgroup = lv.group_get_default()
         if focusgroup:
             focusgroup.add_obj(settings_button)
-        if False: # send button disabled for now, not implemented
-            send_button = lv.button(self.main_screen)
-            send_button.set_size(lv.pct(20), lv.pct(25))
-            send_button.align_to(settings_button, lv.ALIGN.OUT_TOP_MID, 0, -pct_of_display_height(2))
-            send_button.add_event_cb(self.send_button_tap,lv.EVENT.CLICKED,None)
-            send_label = lv.label(send_button)
-            send_label.set_text(lv.SYMBOL.UPLOAD)
-            send_label.set_style_text_font(lv.font_montserrat_24, lv.PART.MAIN)
-            send_label.center()
 
         # Track wallet-mode widgets so they can be hidden/shown as a group
         self.wallet_container_widgets = [balance_line, self.balance_label, self.receive_qr, self.payments_label, self.hero_container, settings_button]
@@ -837,7 +828,9 @@ class DisplayWallet(Activity):
         )
     
     def redraw_payments_cb(self):
-        # this gets called from another thread (the wallet) so make sure it happens in the LVGL thread using lv.async_call():
+        # Called from the wallet's polling task. MicroPython asyncio is
+        # single-threaded and cooperative, so this runs on the same event
+        # loop as LVGL — direct widget writes are safe between awaits.
         self.payments_label.set_text(str(self.wallet.payment_list))
 
     def redraw_static_receive_code_cb(self):
@@ -862,10 +855,6 @@ class DisplayWallet(Activity):
                 print(f"WARNING: {error} (keeping cached data on screen)")
             else:
                 self.payments_label.set_text(str(error))
-
-    def send_button_tap(self, event):
-        print("send_button clicked")
-        self.confetti.start() # for testing the receive animation
 
     def settings_button_tap(self, event):
         self.destination = MainSettingsActivity  # prevent wallet.stop() in onPause

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -456,6 +456,9 @@ class DisplayWallet(Activity):
         self.welcome_container.set_flex_align(lv.FLEX_ALIGN.START, lv.FLEX_ALIGN.CENTER, lv.FLEX_ALIGN.CENTER)
         self.welcome_container.set_scrollbar_mode(lv.SCROLLBAR_MODE.OFF)
         self.welcome_container.add_flag(lv.obj.FLAG.HIDDEN)
+        # Opaque welcome screen bg follows the theme (pure black in dark mode,
+        # pure white in light) — otherwise LVGL's default dark-grey shows through.
+        _apply_screen_theme(self.welcome_container)
 
         welcome_title = lv.label(self.welcome_container)
         welcome_title.set_text("Lightning Piggy")
@@ -521,8 +524,11 @@ class DisplayWallet(Activity):
         self.splash_container = lv.obj(self.main_screen)
         self.splash_container.set_size(lv.pct(100), lv.pct(100))
         self.splash_container.set_style_border_width(0, lv.PART.MAIN)
-        # Let splash background follow the theme (don't hardcode white)
+        # Splash bg is opaque and follows the theme — pure black in dark mode,
+        # pure white in light. Without this, LVGL's default dark-grey leaks
+        # through on first boot before _apply_qr_theme has had a chance to run.
         self.splash_container.set_style_bg_opa(lv.OPA.COVER, lv.PART.MAIN)
+        _apply_screen_theme(self.splash_container)
         self.splash_container.set_flex_flow(lv.FLEX_FLOW.COLUMN)
         self.splash_container.set_flex_align(lv.FLEX_ALIGN.CENTER, lv.FLEX_ALIGN.CENTER, lv.FLEX_ALIGN.CENTER)
         self.splash_container.set_scrollbar_mode(lv.SCROLLBAR_MODE.OFF)
@@ -735,6 +741,13 @@ class DisplayWallet(Activity):
         # Settings-cog icon colour tracks the theme (white in dark mode, black in light).
         if hasattr(self, 'settings_icon'):
             self.settings_icon.set_style_text_color(self._icon_color(), lv.PART.MAIN)
+        # Splash + welcome containers are opaque overlays; keep their bg in sync
+        # with the screen so a theme flip while either is visible doesn't leave
+        # a stale dark-grey rectangle behind.
+        if getattr(self, 'splash_container', None) is not None:
+            _apply_screen_theme(self.splash_container)
+        if getattr(self, 'welcome_container', None) is not None:
+            _apply_screen_theme(self.welcome_container)
         # Re-render balance in case denomination setting changed
         if hasattr(self, '_last_balance'):
             self.display_balance(self._last_balance)

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -80,14 +80,53 @@ class WalletSettingsActivity(SettingsActivity):
         _add_floating_back_button(screen, self.finish)
 
 
+class _AppThemeView:
+    """Minimal prefs-like view for AppearanceManager.init() — lets us force
+    theme_light_dark to a specific value while preserving the OS primary color,
+    without touching OS prefs on disk. Only exposes get_string() because that's
+    all AppearanceManager.init() reads."""
+    def __init__(self, theme_light_dark, primary_color):
+        self._data = {
+            "theme_light_dark": theme_light_dark,
+            "theme_primary_color": primary_color,
+        }
+
+    def get_string(self, key, default=None):
+        return self._data.get(key, default)
+
+
+def _apply_displaywallet_theme(app_prefs):
+    """Apply the effective Light/Dark theme for displaywallet.
+
+    If the app has a local `theme_override` pref ("light"/"dark"), that wins
+    and is applied via a synthesised prefs view — OS prefs on disk are NEVER
+    modified. Otherwise the OS setting is applied verbatim.
+    """
+    override = app_prefs.get_string("theme_override", "")
+    os_prefs = SharedPreferences("com.micropythonos.settings")
+    if override in ("light", "dark"):
+        primary_color = os_prefs.get_string("theme_primary_color", AppearanceManager.DEFAULT_PRIMARY_COLOR)
+        AppearanceManager.init(_AppThemeView(override, primary_color))
+    else:
+        AppearanceManager.init(os_prefs)
+
+
 class CustomiseSettingsActivity(SettingsActivity):
     """Sub-settings screen for display customisation."""
+
     def onCreate(self):
         extras = self.getIntent().extras or {}
         self.prefs = extras.get("prefs")
         # Callbacks are passed via the setting dict from the parent
         setting = extras.get("setting") or {}
         callbacks = setting.get("_callbacks") or {}
+        # Theme row shows the effective mode. If the app has a local override
+        # set, use that; otherwise show whatever the OS theme resolves to.
+        override = self.prefs.get_string("theme_override", "")
+        if override in ("light", "dark"):
+            theme_label = override.capitalize()
+        else:
+            theme_label = "Light" if AppearanceManager.is_light_mode() else "Dark"
         self.settings = [
             {"title": "Balance Denomination", "key": "balance_denomination", "ui": "activity",
              "activity_class": DenominationSettingsActivity,
@@ -97,12 +136,37 @@ class CustomiseSettingsActivity(SettingsActivity):
              "ui_options": [("Lightning Piggy", "lightningpiggy"), ("Lightning Penguin", "lightningpenguin"), ("None", "none")],
              "default_value": "lightningpiggy",
              "changed_callback": callbacks.get("hero_image")},
+            {"title": "Theme", "key": "theme_override", "activity_class": True,
+             "placeholder": theme_label},
         ]
         screen = lv.obj()
         screen.set_style_pad_all(DisplayMetrics.pct_of_width(2), lv.PART.MAIN)
         screen.set_flex_flow(lv.FLEX_FLOW.COLUMN)
         screen.set_style_border_width(0, lv.PART.MAIN)
         self.setContentView(screen)
+
+    def startSettingActivity(self, setting):
+        """Inline toggle for Theme (Light ↔ Dark). Writes only to the app's own
+        prefs — OS-level theme is never modified, so other apps keep the
+        user's OS preference."""
+        if setting.get("key") == "theme_override":
+            # Determine current effective mode and flip it.
+            current_override = self.prefs.get_string("theme_override", "")
+            if current_override in ("light", "dark"):
+                currently_light = (current_override == "light")
+            else:
+                currently_light = AppearanceManager.is_light_mode()
+            new_value = "dark" if currently_light else "light"
+            editor = self.prefs.edit()
+            editor.put_string("theme_override", new_value)
+            editor.commit()
+            # Apply immediately via the synthesised prefs (no OS disk writes)
+            _apply_displaywallet_theme(self.prefs)
+            value_label = setting.get("value_label")
+            if value_label:
+                value_label.set_text(new_value.capitalize())
+        else:
+            super().startSettingActivity(setting)
 
     def onResume(self, screen):
         super().onResume(screen)
@@ -453,6 +517,9 @@ class DisplayWallet(Activity):
 
     def onResume(self, main_screen):
         super().onResume(main_screen)
+        # Ensure the app's effective theme (local override or OS) is applied.
+        # This never writes to OS prefs — see _apply_displaywallet_theme.
+        _apply_displaywallet_theme(self.prefs)
         cm = ConnectivityManager.get()
         cm.register_callback(self.network_changed)
         if not self.splash_shown:
@@ -463,6 +530,9 @@ class DisplayWallet(Activity):
         else:
             # Returning from settings or other activity
             self._update_hero_image()
+            # Re-apply theme-dependent styles every time we return — the user
+            # may have toggled Light/Dark in the Customise settings.
+            self._apply_qr_theme()
             if self.wallet and self.wallet.is_running():
                 # Wallet already running — just redisplay, no re-fetch
                 if hasattr(self, '_last_balance'):
@@ -471,12 +541,20 @@ class DisplayWallet(Activity):
                     self.payments_label.set_text(str(self.wallet.payment_list))
             else:
                 # Wallet not running — reconnect
-                self._apply_qr_theme()
                 self.network_changed(cm.is_online())
 
     def onPause(self, main_screen):
-        if self.wallet and self.destination not in (FullscreenQR, MainSettingsActivity):
+        leaving_app = self.destination not in (FullscreenQR, MainSettingsActivity)
+        if self.wallet and leaving_app:
             self.wallet.stop() # don't stop the wallet for fullscreen QR or settings
+        if leaving_app:
+            # Restore the OS-level theme so the launcher and other apps see the
+            # user's OS preference unmodified (our theme override only applies
+            # while displaywallet is foregrounded).
+            try:
+                AppearanceManager.init(SharedPreferences("com.micropythonos.settings"))
+            except Exception as e:
+                print("displaywallet: failed to restore OS theme:", e)
         self.destination = None
         cm = ConnectivityManager.get()
         cm.unregister_callback(self.network_changed)
@@ -609,7 +687,13 @@ class DisplayWallet(Activity):
         return (lv.color_black(), lv.color_white())
 
     def _apply_qr_theme(self):
-        """Reapply QR colors and symbol when returning from settings."""
+        """Reapply theme-dependent styles (screen bg, QR colors) when returning from settings."""
+        # Screen background follows light/dark mode — otherwise the hardcoded
+        # bg from onCreate lingers after a theme toggle.
+        if AppearanceManager.is_light_mode():
+            self.main_screen.set_style_bg_color(lv.color_white(), lv.PART.MAIN)
+        else:
+            self.main_screen.set_style_bg_color(lv.color_hex(0x15171A), lv.PART.MAIN)
         dark, light = self._qr_colors()
         self.receive_qr.set_dark_color(dark)
         self.receive_qr.set_light_color(light)

--- a/com.lightningpiggy.displaywallet/assets/fullscreen_qr.py
+++ b/com.lightningpiggy.displaywallet/assets/fullscreen_qr.py
@@ -10,13 +10,20 @@ class FullscreenQR(Activity):
         qr_screen = lv.obj()
         qr_screen.set_scrollbar_mode(lv.SCROLLBAR_MODE.OFF)
         qr_screen.set_scroll_dir(lv.DIR.NONE)
+        # Explicit screen bg — otherwise LVGL's default dark-theme charcoal
+        # shows around the QR instead of matching the main display's pure
+        # black / pure white.
+        if AppearanceManager.is_light_mode():
+            qr_screen.set_style_bg_color(lv.color_white(), lv.PART.MAIN)
+        else:
+            qr_screen.set_style_bg_color(lv.color_black(), lv.PART.MAIN)
         qr_screen.add_event_cb(lambda e: self.finish(),lv.EVENT.CLICKED,None)
         big_receive_qr = lv.qrcode(qr_screen)
         big_receive_qr.set_size(round(DisplayMetrics.min_dimension()*0.9))
         if not AppearanceManager.is_light_mode():
             big_receive_qr.set_dark_color(lv.color_white())
-            big_receive_qr.set_light_color(lv.color_hex(0x15171A))
-            border_color = lv.color_hex(0x15171A)
+            big_receive_qr.set_light_color(lv.color_black())
+            border_color = lv.color_black()
         else:
             big_receive_qr.set_dark_color(lv.color_black())
             big_receive_qr.set_light_color(lv.color_white())

--- a/com.lightningpiggy.displaywallet/assets/nwc_wallet.py
+++ b/com.lightningpiggy.displaywallet/assets/nwc_wallet.py
@@ -226,7 +226,9 @@ class NWCWallet(Wallet):
 
     def parse_nwc_url(self, nwc_url):
         """Parse Nostr Wallet Connect URL to extract pubkey, relays, secret, and lud16."""
-        print(f"DEBUG: Starting to parse NWC URL: {nwc_url}")
+        # Don't log the raw URL — the query string contains the secret, which
+        # authorises spending. Log only state transitions, not content.
+        print("DEBUG: Starting to parse NWC URL")
         try:
             # Remove 'nostr+walletconnect://' or 'nwc:' prefix
             if nwc_url.startswith('nostr+walletconnect://'):
@@ -238,10 +240,10 @@ class NWCWallet(Wallet):
             else:
                 print(f"DEBUG: No recognized prefix found in URL")
                 raise ValueError("Invalid NWC URL: missing 'nostr+walletconnect://' or 'nwc:' prefix")
-            print(f"DEBUG: URL after prefix removal: {nwc_url}")
+            # (URL after prefix removal is not logged — still contains secret.)
             # urldecode because the relay might have %3A%2F%2F etc
             nwc_url = urldecode(nwc_url)
-            print(f"after urldecode: {nwc_url}")
+            # (urldecoded URL also not logged — still contains secret.)
             # Split into pubkey and query params
             parts = nwc_url.split('?')
             pubkey = parts[0]
@@ -263,7 +265,8 @@ class NWCWallet(Wallet):
                         relays.append(relay)
                     elif param.startswith('secret='):
                         secret = param[7:]
-                        print(f"DEBUG: Extracted secret: {secret}")
+                        # Never log the secret itself — it authorises spending.
+                        print("DEBUG: Extracted secret (content redacted)")
                     elif param.startswith('lud16='):
                         lud16 = param[6:]
                         print(f"DEBUG: Extracted lud16: {lud16}")
@@ -274,9 +277,14 @@ class NWCWallet(Wallet):
             # Validate secret (should be 64 hex characters)
             if len(secret) != 64 or not all(c in '0123456789abcdef' for c in secret):
                 raise ValueError("Invalid NWC URL: secret must be 64 hex characters")
-            print(f"DEBUG: Parsed NWC data - Relay: {relays}, Pubkey: {pubkey}, Secret: {secret}, lud16: {lud16}")
+            # Relays + lud16 are not sensitive; pubkey + secret are redacted
+            # (pubkey is effectively public once paired, but still fingerprints
+            # the user's wallet provider to anyone reading logs; secret
+            # authorises spending).
+            print(f"DEBUG: Parsed NWC data - Relays: {relays}, lud16: {lud16}")
             return relays, pubkey, secret, lud16
         except Exception as e:
-            raise RuntimeError(f"Exception parsing NWC URL {nwc_url}: {e}")
+            # Don't include the NWC URL in the error — it contains the secret.
+            raise RuntimeError(f"Exception parsing NWC URL: {e}")
 
 

--- a/com.lightningpiggy.displaywallet/assets/wallet.py
+++ b/com.lightningpiggy.displaywallet/assets/wallet.py
@@ -64,7 +64,8 @@ class Wallet:
         print("handle_new_payment")
         self.payment_list.add(new_payment)
         wallet_cache.save_cache(payments=self.payment_list)
-        self.payments_updated_cb()
+        if self.payments_updated_cb:
+            self.payments_updated_cb()
 
     def handle_new_payments(self, new_payments):
         if not self.keep_running:
@@ -74,7 +75,8 @@ class Wallet:
             print("new list of payments")
             self.payment_list = new_payments
             wallet_cache.save_cache(payments=self.payment_list)
-            self.payments_updated_cb()
+            if self.payments_updated_cb:
+                self.payments_updated_cb()
 
     def handle_new_static_receive_code(self, new_static_receive_code):
         print("handle_new_static_receive_code")

--- a/tests/test_displaywallet_theme_override.py
+++ b/tests/test_displaywallet_theme_override.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for the app-local theme override helper in the Lightning Piggy app.
+
+Targets LightningPiggyApp PR #27 (app-local Light/Dark theme toggle). The
+override lives in the app's own prefs under `theme_override`; if set, it
+takes precedence over the OS-level theme but never writes to OS prefs.
+
+This test covers the `_AppThemeView` adapter class that feeds
+AppearanceManager.init() a synthesised prefs view (override value + OS
+primary color) without touching OS prefs on disk.
+
+The vendored tests/unittest.sh auto-injects the app's assets/ dir into
+sys.path, so these imports work without any further path manipulation.
+
+Usage (from the LightningPiggyApp repo root):
+    Desktop: bash tests/unittest.sh tests/test_displaywallet_theme_override.py
+    Device:  bash tests/unittest.sh tests/test_displaywallet_theme_override.py --ondevice
+"""
+
+import unittest
+
+# The _AppThemeView class is defined at module-level in displaywallet.py.
+# Importing displaywallet pulls in LVGL+SettingsActivity machinery which is
+# heavy/noisy, but it works in the test harness. If the feature isn't landed
+# yet, _AppThemeView won't exist and the tests skip gracefully.
+try:
+    import displaywallet
+    _HAVE_APP_THEME_VIEW = hasattr(displaywallet, "_AppThemeView")
+except Exception:
+    _HAVE_APP_THEME_VIEW = False
+
+
+@unittest.skipUnless(_HAVE_APP_THEME_VIEW, "_AppThemeView not installed (PR #27 not landed)")
+class TestAppThemeView(unittest.TestCase):
+    """The `_AppThemeView` duck-type mimics the `SharedPreferences.get_string`
+    surface needed by `AppearanceManager.init()`, so the theme can be
+    reinitialised with an app-local override without touching OS prefs."""
+
+    def test_returns_stored_theme_light_dark(self):
+        v = displaywallet._AppThemeView("dark", "0x1234AB")
+        self.assertEqual(v.get_string("theme_light_dark"), "dark")
+
+    def test_returns_stored_primary_color(self):
+        v = displaywallet._AppThemeView("light", "0xABCDEF")
+        self.assertEqual(v.get_string("theme_primary_color"), "0xABCDEF")
+
+    def test_unknown_key_returns_default(self):
+        v = displaywallet._AppThemeView("dark", "0x123456")
+        self.assertEqual(v.get_string("unrelated_key", "fallback"), "fallback")
+        # And None default when no default provided
+        self.assertIsNone(v.get_string("unrelated_key"))
+
+    def test_does_not_expose_set_or_edit(self):
+        # The view intentionally exposes only get_string — AppearanceManager.init
+        # reads from it and shouldn't try to write. Missing setters would be a
+        # regression.
+        v = displaywallet._AppThemeView("light", "0x000000")
+        self.assertFalse(hasattr(v, "set_string"))
+        self.assertFalse(hasattr(v, "edit"))
+
+
+@unittest.skipUnless(_HAVE_APP_THEME_VIEW, "_AppThemeView not installed")
+class TestAppThemeViewIntegrationWithAppearanceManager(unittest.TestCase):
+    """Once PR #120 lands, AppearanceManager.init() uses edit/put_string/commit
+    on its prefs arg when called from the setters — but *not* from init() itself,
+    which only reads via get_string. So an _AppThemeView (read-only) is
+    compatible with init() even though it has no edit() method."""
+
+    def test_init_reads_from_view_without_writing(self):
+        from mpos import AppearanceManager
+        saved = AppearanceManager.is_light_mode()
+        try:
+            v = displaywallet._AppThemeView("dark", "0xF0A010")
+            # Must not raise, must not attempt to write.
+            AppearanceManager.init(v)
+            self.assertFalse(AppearanceManager.is_light_mode())
+
+            v = displaywallet._AppThemeView("light", "0xF0A010")
+            AppearanceManager.init(v)
+            self.assertTrue(AppearanceManager.is_light_mode())
+        finally:
+            AppearanceManager._is_light_mode = saved
+
+
+_HAVE_APPLY_SCREEN_THEME = _HAVE_APP_THEME_VIEW and hasattr(displaywallet, "_apply_screen_theme") if _HAVE_APP_THEME_VIEW else False
+
+
+@unittest.skipUnless(_HAVE_APPLY_SCREEN_THEME, "_apply_screen_theme not installed")
+class TestApplyScreenTheme(unittest.TestCase):
+    """`_apply_screen_theme(screen)` forces an explicit bg colour that matches
+    the app's main display — pure black in dark mode, pure white in light mode.
+    MUST set both directions: once an explicit style is set it overrides LVGL's
+    default-theme bg, so a dark→light toggle would leave a lingering black bg
+    if we only set black."""
+
+    class _RecordingScreen:
+        """Minimal screen stub that records the last `set_style_bg_color` call."""
+        def __init__(self):
+            self.last_color = None
+            self.last_part = None
+            self.calls = 0
+
+        def set_style_bg_color(self, color, part):
+            self.last_color = color
+            self.last_part = part
+            self.calls += 1
+
+    def _force_mode(self, is_light):
+        from mpos import AppearanceManager
+        AppearanceManager._is_light_mode = bool(is_light)
+
+    def test_dark_mode_sets_black_bg(self):
+        from mpos import AppearanceManager
+        saved = AppearanceManager.is_light_mode()
+        try:
+            self._force_mode(False)
+            import lvgl as lv
+            screen = self._RecordingScreen()
+            displaywallet._apply_screen_theme(screen)
+            # Compare underlying 0xRRGGBB int because LVGL color_t objects
+            # don't implement __eq__ across all builds.
+            self.assertEqual(screen.calls, 1)
+            self.assertEqual(screen.last_part, lv.PART.MAIN)
+            # color_black == 0x000000
+            self.assertEqual(screen.last_color.full if hasattr(screen.last_color, 'full') else None,
+                             lv.color_black().full if hasattr(lv.color_black(), 'full') else None)
+        finally:
+            AppearanceManager._is_light_mode = saved
+
+    def test_light_mode_sets_white_bg(self):
+        from mpos import AppearanceManager
+        saved = AppearanceManager.is_light_mode()
+        try:
+            self._force_mode(True)
+            import lvgl as lv
+            screen = self._RecordingScreen()
+            displaywallet._apply_screen_theme(screen)
+            self.assertEqual(screen.calls, 1)
+            self.assertEqual(screen.last_part, lv.PART.MAIN)
+            self.assertEqual(screen.last_color.full if hasattr(screen.last_color, 'full') else None,
+                             lv.color_white().full if hasattr(lv.color_white(), 'full') else None)
+        finally:
+            AppearanceManager._is_light_mode = saved
+
+    def test_applies_in_both_directions(self):
+        """Regression: if only dark mode set a bg, a dark→light flip leaves the
+        black style lingering on screen. Guard that BOTH branches write."""
+        from mpos import AppearanceManager
+        saved = AppearanceManager.is_light_mode()
+        try:
+            screen = self._RecordingScreen()
+
+            self._force_mode(False)
+            displaywallet._apply_screen_theme(screen)
+            dark_count = screen.calls
+
+            self._force_mode(True)
+            displaywallet._apply_screen_theme(screen)
+            light_count = screen.calls
+
+            self.assertEqual(dark_count, 1, "dark mode should set bg once")
+            self.assertEqual(light_count, 2, "light mode should also set bg (not skip)")
+        finally:
+            AppearanceManager._is_light_mode = saved
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest.sh
+++ b/tests/unittest.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# Vendored from MicroPythonOS/tests/unittest.sh so the LightningPiggy test
+# suite is self-contained and doesn't depend on the MicroPythonOS repo
+# layout. Kept as close to upstream as practical to ease future sync.
+#
+# Changes vs upstream:
+#   - MicroPythonOS checkout discovered via $MPOS_HOME (env var) with a
+#     ../MicroPythonOS sibling-directory default, instead of hardcoded
+#     relative paths.
+#   - The Lightning Piggy assets/ dir is auto-injected into sys.path so
+#     tests can `import wallet_cache` etc. without manual path hacks.
+
+mydir=$(readlink -f "$0")
+mydir=$(dirname "$mydir")
+testdir="$mydir"
+
+# Locate the MicroPythonOS checkout (needed for the desktop binary,
+# internal_filesystem, and mpremote). Precedence:
+#   1. $MPOS_HOME env var
+#   2. ../MicroPythonOS (sibling layout: /parent/{LightningPiggyApp,MicroPythonOS})
+if [ -n "$MPOS_HOME" ]; then
+	mpos=$(readlink -f "$MPOS_HOME")
+elif [ -d "$mydir/../../MicroPythonOS" ]; then
+	mpos=$(readlink -f "$mydir/../../MicroPythonOS")
+else
+	echo "ERROR: MicroPythonOS checkout not found."
+	echo "Set \$MPOS_HOME, or clone MicroPythonOS as a sibling of LightningPiggyApp."
+	exit 1
+fi
+
+scriptdir="$mpos/scripts"
+fs="$mpos/internal_filesystem"
+mpremote="$mpos/lvgl_micropython/lib/micropython/tools/mpremote/mpremote.py"
+#heapsize=8M
+heapsize=16M # on desktop, a bit more is warranted (different C library etc)
+
+# The Lightning Piggy app's assets/ dir — auto-injected into sys.path so
+# tests can `from payment import Payment`, `import wallet_cache`, etc.
+lp_assets=$(readlink -f "$mydir/../com.lightningpiggy.displaywallet/assets")
+if [ ! -d "$lp_assets" ]; then
+	echo "ERROR: Lightning Piggy assets dir not found at $lp_assets"
+	exit 1
+fi
+
+# Parse arguments
+ondevice=""
+onetest=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ondevice)
+            ondevice="yes"
+            ;;
+        *)
+            onetest="$1"
+            ;;
+    esac
+    shift
+done
+
+# print os and set binary
+os_name=$(uname -s)
+if [ "$os_name" = "Darwin" ]; then
+        echo "Running on macOS"
+        binary="$mpos"/lvgl_micropython/build/lvgl_micropy_macOS
+else
+        # other cases can be added here
+        echo "Running on $os_name"
+        binary="$mpos"/lvgl_micropython/build/lvgl_micropy_unix
+fi
+
+binary=$(readlink -f "$binary")
+if [ ! -x "$binary" ]; then
+	echo "ERROR: MicroPythonOS desktop binary not found/executable at $binary"
+	echo "Build it first: cd $mpos && bash scripts/build_mpos.sh \$(uname -s | tr A-Z a-z)"
+	exit 1
+fi
+chmod +x "$binary"
+
+# make sure no autostart is configured:
+rm -f "$fs"/data/com.micropythonos.settings/config.json
+
+one_test() {
+	file="$1"
+	if [ ! -f "$file" ]; then
+		echo "ERROR: $file is not a regular, existing file!"
+		exit 1
+	fi
+	pushd "$fs"
+	echo "Testing $file"
+
+	# Detect if this is a graphical test (filename contains "graphical")
+	if echo "$file" | grep -q "graphical"; then
+		echo "Detected graphical test - including boot and main files"
+		is_graphical=1
+		# Get absolute path to tests directory for imports
+		tests_abs_path=$(readlink -f "$testdir")
+	else
+		is_graphical=0
+	fi
+
+	if [ -z "$ondevice" ]; then
+		# Desktop execution
+		if [ $is_graphical -eq 1 ]; then
+			echo "Graphical test: include main.py"
+			"$binary" -X heapsize=$heapsize -c "import sys ; sys.path.insert(0, 'lib') ; sys.path.append(\"$tests_abs_path\") ; sys.path.append(\"$lp_assets\") ; import mpos ; mpos.TaskManager.disable() ; $(cat main.py)
+$(cat $file)
+result = unittest.main() ; sys.exit(0 if result.wasSuccessful() else 1) "
+	           result=$?
+		else
+			echo "Regular test: no boot files"
+			"$binary" -X heapsize=$heapsize -c "import sys ; sys.path.insert(0, 'lib') ; sys.path.append(\"$lp_assets\") ; import mpos ; mpos.TaskManager.disable() ; $(cat main.py)
+$(cat $file)
+result = unittest.main() ; sys.exit(0 if result.wasSuccessful() else 1) "
+	           result=$?
+		fi
+	else
+		if [ ! -z "$ondevice" ]; then
+			echo "Hack: reset the device to make sure no previous UnitTest classes have been registered..."
+			"$mpremote" reset
+			sleep 30
+		fi
+
+		echo "Device execution"
+		# NOTE: On device, the OS is already running with boot.py and main.py executed,
+		# so we don't need to (and shouldn't) re-run them. The system is already initialized.
+		# Lightning Piggy assets live at /apps/com.lightningpiggy.displaywallet/assets/
+		# on device — use that path instead of $lp_assets (which is host-side).
+		cleanname=$(echo "$file" | sed "s#/#_#g")
+		testlog=/tmp/"$cleanname".log
+		echo "$test logging to $testlog"
+		if [ $is_graphical -eq 1 ]; then
+			# Graphical test: system already initialized, just add test paths
+			"$mpremote" exec "import sys ; sys.path.insert(0, 'lib') ; sys.path.append('tests') ; sys.path.append('apps/com.lightningpiggy.displaywallet/assets') ; import mpos ; mpos.TaskManager.disable() ; $(cat main.py)
+$(cat $file)
+result = unittest.main()
+if result.wasSuccessful():
+		  print('TEST WAS A SUCCESS')
+else:
+		  print('TEST WAS A FAILURE')
+" | tee "$testlog"
+		else
+			# Regular test: no boot files
+			"$mpremote" exec "import sys ; sys.path.insert(0, 'lib') ; sys.path.append('tests') ; sys.path.append('apps/com.lightningpiggy.displaywallet/assets') ; import mpos ; mpos.TaskManager.disable() ; $(cat main.py)
+$(cat $file)
+result = unittest.main()
+if result.wasSuccessful():
+		  print('TEST WAS A SUCCESS')
+else:
+		  print('TEST WAS A FAILURE')
+" | tee "$testlog"
+		fi
+		grep -q "TEST WAS A SUCCESS" "$testlog"
+		result=$?
+	fi
+	popd
+	return "$result"
+}
+
+failed=0
+ran=0
+
+if [ -z "$onetest" ]; then
+	echo "Usage: $0 [one_test_to_run.py] [--ondevice]"
+	echo "Example: $0 tests/test_onchain_wallet.py"
+	echo "Example: $0 tests/test_onchain_wallet.py --ondevice"
+	echo "Example: $0 --ondevice"
+	echo
+	echo "If no test is specified: run all tests from $testdir on local machine."
+	echo
+	echo "The '--ondevice' flag will run the test(s) on a connected device using mpremote.py over a serial connection."
+	echo
+	echo "MicroPythonOS checkout resolved to: $mpos"
+	echo "Lightning Piggy assets resolved to: $lp_assets"
+	files=$(find "$testdir" -iname "test_*.py" )
+	for file in $files; do
+		one_test "$file"
+		result=$?
+		if [ $result -ne 0 ]; then
+			echo -e "\n\n\nWARNING: test $file got error $result !!!\n\n\n"
+			failed=$(expr $failed \+ 1)
+			exit 1
+		else
+			ran=$(expr $ran \+ 1)
+		fi
+	done
+else
+	echo "doing $onetest"
+	one_test $(readlink -f "$onetest")
+	result=$?
+	if [ $result -ne 0 ]; then
+		echo "Test returned result: $result"
+		failed=1
+	fi
+fi
+
+
+if [ $failed -ne 0 ]; then
+        echo "ERROR: $failed of the $ran tests failed"
+        exit 1
+else
+	echo "GOOD: none of the $ran tests failed"
+	exit 0
+fi


### PR DESCRIPTION
## Summary
Adds a **Theme** row under *Wallet → Customise* with an inline Light ↔ Dark toggle that is **local to the Lightning Piggy app**. The OS-level theme preference is never modified — when the user leaves the app, the OS theme is restored so the launcher and other apps keep the user's system-wide preference.

## Design
| Pref | Where stored | Scope |
|---|---|---|
| `theme_override` (`"light"` / `"dark"` / unset) | `com.lightningpiggy.displaywallet/config.json` | Just this app |
| `theme_light_dark` (OS) | `com.micropythonos.settings/config.json` | System-wide — **never written by this PR** |

**Flow:**
- `CustomiseSettingsActivity` shows a Theme row labelled with the active mode.
- Tapping writes only `theme_override` to the app's prefs and calls `_apply_displaywallet_theme()`, which feeds `AppearanceManager.init()` a synthesised prefs view — the override value for `theme_light_dark` plus the OS's `theme_primary_color`. No OS file writes.
- `DisplayWallet.onResume` re-applies the effective theme on every entry/return from sub-activities.
- `DisplayWallet.onPause` (only when leaving the app entirely — not when opening Settings or FullscreenQR) calls `AppearanceManager.init(os_prefs)` so the launcher and other apps see the OS theme unmodified.

## UX
- Initial state: follows OS theme (no override set). Row shows `Light` / `Dark` based on current OS value.
- Tap once: sets an app-local override. Other apps unchanged.
- Tap again: flips the app-local override. Still doesn't affect OS.
- To "reset to OS theme": delete the `theme_override` key from prefs (future iteration could add an explicit "System" option).

## Framework note
`AppearanceManager.set_light_mode()` has a bug — calls `prefs.set_string(...)` which isn't on `SharedPreferences` (correct API is `edit().put_string().commit()`). Worked around here by persisting via the proper API. Worth fixing upstream, but separate PR.

## Changes
| File | Change |
|---|---|
| `com.lightningpiggy.displaywallet/assets/displaywallet.py` | New `_AppThemeView` helper, `_apply_displaywallet_theme()`, Theme row in `CustomiseSettingsActivity`, toggle handler in `startSettingActivity`, `onResume`/`onPause` apply/restore |
| `com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON` | 0.2.6 → 0.2.7 |
| `CHANGELOG.md` | New 0.2.7 section |

## Independence from other open PRs
This PR is independent of #25 (on-chain wallet) and #26 (multi-wallet). All three are draft and queued for the next release; merge order is flexible and whoever lands first keeps 0.2.7.

## Test plan
- [x] Desktop: toggling Light → Dark flips bg/QR colors immediately on return from Settings; toggle persists in `displaywallet/config.json` under `theme_override`
- [x] Device: override applies only while displaywallet is foreground; exiting to launcher restores OS theme; returning to displaywallet re-applies the override
- [x] OS prefs (`com.micropythonos.settings/theme_light_dark`) untouched after toggling in-app
- [ ] Regression: denomination/hero_image/screen_lock flows unchanged