### PR TITLE
Pre-v0.3.0 cleanup: dead code, callback guard, comment fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.3.0
+=====
+- Remove dead send_button code (pre-multi-wallet placeholder that never shipped) and its orphan tap handler
+- Guard the payments_updated_cb callback against a missing assignment (consistency with the peer callbacks)
+- Correct a misleading comment that claimed wallet callbacks run "on another thread" — they actually run on the same event loop as LVGL via TaskManager.create_task
+
 0.2.6
 =====
 - Use native ₿ font glyph for balance and transaction amounts (replaces PNG images)

--- a/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
+++ b/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
@@ -3,10 +3,10 @@
 "publisher": "LightningPiggy Foundation",
 "short_description": "Display wallet that shows balance, transactions, receive QR code etc.",
 "long_description": "See https://www.LightningPiggy.com",
-"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.2.6_64x64.png",
-"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.2.6.mpk",
+"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.3.0_64x64.png",
+"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.3.0.mpk",
 "fullname": "com.lightningpiggy.displaywallet",
-"version": "0.2.6",
+"version": "0.3.0",
 "category": "finance",
 "activities": [
     {

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -341,15 +341,6 @@ class DisplayWallet(Activity):
         focusgroup = lv.group_get_default()
         if focusgroup:
             focusgroup.add_obj(settings_button)
-        if False: # send button disabled for now, not implemented
-            send_button = lv.button(self.main_screen)
-            send_button.set_size(lv.pct(20), lv.pct(25))
-            send_button.align_to(settings_button, lv.ALIGN.OUT_TOP_MID, 0, -pct_of_display_height(2))
-            send_button.add_event_cb(self.send_button_tap,lv.EVENT.CLICKED,None)
-            send_label = lv.label(send_button)
-            send_label.set_text(lv.SYMBOL.UPLOAD)
-            send_label.set_style_text_font(lv.font_montserrat_24, lv.PART.MAIN)
-            send_label.center()
 
         # Track wallet-mode widgets so they can be hidden/shown as a group
         self.wallet_container_widgets = [balance_line, self.balance_label, self.receive_qr, self.payments_label, self.hero_container, settings_button]
@@ -705,7 +696,9 @@ class DisplayWallet(Activity):
         )
     
     def redraw_payments_cb(self):
-        # this gets called from another thread (the wallet) so make sure it happens in the LVGL thread using lv.async_call():
+        # Called from the wallet's polling task. MicroPython asyncio is
+        # single-threaded and cooperative, so this runs on the same event
+        # loop as LVGL — direct widget writes are safe between awaits.
         self.payments_label.set_text(str(self.wallet.payment_list))
 
     def redraw_static_receive_code_cb(self):
@@ -730,10 +723,6 @@ class DisplayWallet(Activity):
                 print(f"WARNING: {error} (keeping cached data on screen)")
             else:
                 self.payments_label.set_text(str(error))
-
-    def send_button_tap(self, event):
-        print("send_button clicked")
-        self.confetti.start() # for testing the receive animation
 
     def settings_button_tap(self, event):
         self.destination = MainSettingsActivity  # prevent wallet.stop() in onPause

--- a/com.lightningpiggy.displaywallet/assets/wallet.py
+++ b/com.lightningpiggy.displaywallet/assets/wallet.py
@@ -64,7 +64,8 @@ class Wallet:
         print("handle_new_payment")
         self.payment_list.add(new_payment)
         wallet_cache.save_cache(payments=self.payment_list)
-        self.payments_updated_cb()
+        if self.payments_updated_cb:
+            self.payments_updated_cb()
 
     def handle_new_payments(self, new_payments):
         if not self.keep_running:
@@ -74,7 +75,8 @@ class Wallet:
             print("new list of payments")
             self.payment_list = new_payments
             wallet_cache.save_cache(payments=self.payment_list)
-            self.payments_updated_cb()
+            if self.payments_updated_cb:
+                self.payments_updated_cb()
 
     def handle_new_static_receive_code(self, new_static_receive_code):
         print("handle_new_static_receive_code")


### PR DESCRIPTION
## Summary

Three small pre-release hygiene changes, independent of the themed / multi-wallet work:

1. **Drop dead `send_button` code** (`displaywallet.py`) — an `if False:` block wraps a Send button that was never implemented, plus its orphan `send_button_tap` handler. 12 lines of weight in a file we're asking reviewers to read.
2. **Guard `payments_updated_cb`** (`wallet.py`) — the call sites at `handle_new_payment` / `handle_new_payments` didn't check the callback was set, while the peer callbacks (`static_receive_code_updated_cb`, `error_cb`) do. Low-probability crash if a subclass's fetch completes before `start()` has assigned the callback. One-line consistency fix × 2.
3. **Fix misleading threading comment** (`displaywallet.py`) — a comment claimed `redraw_payments_cb` runs "on another thread (the wallet)" and should use `lv.async_call`. Wallets use `TaskManager.create_task` (asyncio), which runs on the same event loop as LVGL. Corrected comment explains the actual model so future readers don't chase a phantom threading bug.

## Release target

Bumps MANIFEST to 0.3.0 and adds a `0.3.0` CHANGELOG section. This is part of a four-PR split heading toward v0.3.0 (see PR description trail in #27).

## Dependencies

None — branched off `master` (0.2.6), independent of the theme-toggle stack and the security hotfix.

## Test plan

- [x] Existing behaviour unchanged on device (all pre-existing flows still work)
- [x] No crash during initial wallet connect (regression guard for the callback None-guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)