### PR TITLE
Add app-local Light/Dark theme toggle in Customise settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.3.0
+=====
+- Light/Dark theme toggle in Customise settings — app-local override that doesn't touch the OS-level theme; other apps and the launcher keep the user's OS preference
+
 0.2.6
 =====
 - Use native ₿ font glyph for balance and transaction amounts (replaces PNG images)

--- a/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
+++ b/com.lightningpiggy.displaywallet/META-INF/MANIFEST.JSON
@@ -3,10 +3,10 @@
 "publisher": "LightningPiggy Foundation",
 "short_description": "Display wallet that shows balance, transactions, receive QR code etc.",
 "long_description": "See https://www.LightningPiggy.com",
-"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.2.6_64x64.png",
-"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.2.6.mpk",
+"icon_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/icons/com.lightningpiggy.displaywallet_0.3.0_64x64.png",
+"download_url": "https://apps.micropythonos.com/apps/com.lightningpiggy.displaywallet/mpks/com.lightningpiggy.displaywallet_0.3.0.mpk",
 "fullname": "com.lightningpiggy.displaywallet",
-"version": "0.2.6",
+"version": "0.3.0",
 "category": "finance",
 "activities": [
     {

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -80,14 +80,55 @@ class WalletSettingsActivity(SettingsActivity):
         _add_floating_back_button(screen, self.finish)
 
 
+class _AppThemeView:
+    """Minimal prefs-like view for AppearanceManager.init() — lets us force
+    theme_light_dark to a specific value while preserving the OS primary color,
+    without touching OS prefs on disk. Only exposes get_string() because that's
+    all AppearanceManager.init() reads."""
+    def __init__(self, theme_light_dark, primary_color):
+        self._data = {
+            "theme_light_dark": theme_light_dark,
+            "theme_primary_color": primary_color,
+        }
+
+    def get_string(self, key, default=None):
+        return self._data.get(key, default)
+
+
+def _apply_displaywallet_theme(app_prefs):
+    """Apply the effective Light/Dark theme for displaywallet.
+
+    If the app has a local `theme_override` pref ("light"/"dark"), that wins
+    and is applied via a synthesised prefs view — OS prefs on disk are NEVER
+    modified. Otherwise the OS setting is applied verbatim.
+    """
+    override = app_prefs.get_string("theme_override", "")
+    os_prefs = SharedPreferences("com.micropythonos.settings")
+    if override in ("light", "dark"):
+        primary_color = os_prefs.get_string("theme_primary_color", AppearanceManager.DEFAULT_PRIMARY_COLOR)
+        AppearanceManager.init(_AppThemeView(override, primary_color))
+    else:
+        AppearanceManager.init(os_prefs)
+
+
 class CustomiseSettingsActivity(SettingsActivity):
     """Sub-settings screen for display customisation."""
+
     def onCreate(self):
         extras = self.getIntent().extras or {}
         self.prefs = extras.get("prefs")
         # Callbacks are passed via the setting dict from the parent
         setting = extras.get("setting") or {}
         callbacks = setting.get("_callbacks") or {}
+        # Theme row shows the effective mode. If the app has a local override
+        # set, use that; otherwise show whatever the OS theme resolves to.
+        # (Using a literal map because MicroPython's str lacks .capitalize().)
+        override = self.prefs.get_string("theme_override", "")
+        theme_display = {"light": "Light", "dark": "Dark"}
+        if override in theme_display:
+            theme_label = theme_display[override]
+        else:
+            theme_label = "Light" if AppearanceManager.is_light_mode() else "Dark"
         self.settings = [
             {"title": "Balance Denomination", "key": "balance_denomination", "ui": "activity",
              "activity_class": DenominationSettingsActivity,
@@ -97,12 +138,43 @@ class CustomiseSettingsActivity(SettingsActivity):
              "ui_options": [("Lightning Piggy", "lightningpiggy"), ("Lightning Penguin", "lightningpenguin"), ("None", "none")],
              "default_value": "lightningpiggy",
              "changed_callback": callbacks.get("hero_image")},
+            {"title": "Theme", "key": "theme_override", "activity_class": True,
+             "placeholder": theme_label},
         ]
         screen = lv.obj()
         screen.set_style_pad_all(DisplayMetrics.pct_of_width(2), lv.PART.MAIN)
         screen.set_flex_flow(lv.FLEX_FLOW.COLUMN)
         screen.set_style_border_width(0, lv.PART.MAIN)
         self.setContentView(screen)
+
+    def startSettingActivity(self, setting):
+        """Inline toggle for Theme (Light ↔ Dark). Writes only to the app's own
+        prefs — OS-level theme is never modified, so other apps keep the
+        user's OS preference."""
+        if setting.get("key") == "theme_override":
+            # Determine current effective mode and flip it.
+            current_override = self.prefs.get_string("theme_override", "")
+            if current_override in ("light", "dark"):
+                currently_light = (current_override == "light")
+            else:
+                currently_light = AppearanceManager.is_light_mode()
+            new_value = "dark" if currently_light else "light"
+            editor = self.prefs.edit()
+            editor.put_string("theme_override", new_value)
+            editor.commit()
+            # Update the label synchronously FIRST, before the theme reinit has
+            # any chance to disturb the widget state.
+            value_label = setting.get("value_label")
+            if value_label:
+                value_label.set_text({"light": "Light", "dark": "Dark"}[new_value])
+            # Defer theme reinit to the next LVGL tick so the current click
+            # event finishes cleanly before LVGL re-themes everything. Calling
+            # lv.theme_default_init() from inside an event handler causes the
+            # setting row's click handlers to misbehave on subsequent taps.
+            prefs = self.prefs
+            lv.async_call(lambda *args: _apply_displaywallet_theme(prefs), None)
+        else:
+            super().startSettingActivity(setting)
 
     def onResume(self, screen):
         super().onResume(screen)
@@ -333,11 +405,11 @@ class DisplayWallet(Activity):
         settings_button.set_style_border_width(0, lv.PART.MAIN)
         settings_button.set_scrollbar_mode(lv.SCROLLBAR_MODE.OFF)
         settings_button.add_event_cb(self.settings_button_tap,lv.EVENT.CLICKED,None)
-        settings_icon = lv.label(settings_button)
-        settings_icon.set_text(lv.SYMBOL.SETTINGS)
-        settings_icon.set_style_text_font(lv.font_montserrat_18, lv.PART.MAIN)
-        settings_icon.set_style_text_color(self._icon_color(), lv.PART.MAIN)
-        settings_icon.center()
+        self.settings_icon = lv.label(settings_button)
+        self.settings_icon.set_text(lv.SYMBOL.SETTINGS)
+        self.settings_icon.set_style_text_font(lv.font_montserrat_18, lv.PART.MAIN)
+        self.settings_icon.set_style_text_color(self._icon_color(), lv.PART.MAIN)
+        self.settings_icon.center()
         focusgroup = lv.group_get_default()
         if focusgroup:
             focusgroup.add_obj(settings_button)
@@ -453,6 +525,15 @@ class DisplayWallet(Activity):
 
     def onResume(self, main_screen):
         super().onResume(main_screen)
+        # Ensure the app's effective theme (local override or OS) is applied.
+        # This never writes to OS prefs — see _apply_displaywallet_theme.
+        _apply_displaywallet_theme(self.prefs)
+        # Re-apply theme-dependent styles (screen bg, QR colors) right away —
+        # onCreate set these based on is_light_mode at construction time, before
+        # our app-local override had a chance to flip it. On first launch after
+        # a theme override is active, the onCreate bg colour is wrong; this
+        # corrects it before the splash even runs.
+        self._apply_qr_theme()
         cm = ConnectivityManager.get()
         cm.register_callback(self.network_changed)
         if not self.splash_shown:
@@ -471,12 +552,20 @@ class DisplayWallet(Activity):
                     self.payments_label.set_text(str(self.wallet.payment_list))
             else:
                 # Wallet not running — reconnect
-                self._apply_qr_theme()
                 self.network_changed(cm.is_online())
 
     def onPause(self, main_screen):
-        if self.wallet and self.destination not in (FullscreenQR, MainSettingsActivity):
+        leaving_app = self.destination not in (FullscreenQR, MainSettingsActivity)
+        if self.wallet and leaving_app:
             self.wallet.stop() # don't stop the wallet for fullscreen QR or settings
+        if leaving_app:
+            # Restore the OS-level theme so the launcher and other apps see the
+            # user's OS preference unmodified (our theme override only applies
+            # while displaywallet is foregrounded).
+            try:
+                AppearanceManager.init(SharedPreferences("com.micropythonos.settings"))
+            except Exception as e:
+                print("displaywallet: failed to restore OS theme:", e)
         self.destination = None
         cm = ConnectivityManager.get()
         cm.unregister_callback(self.network_changed)
@@ -609,13 +698,22 @@ class DisplayWallet(Activity):
         return (lv.color_black(), lv.color_white())
 
     def _apply_qr_theme(self):
-        """Reapply QR colors and symbol when returning from settings."""
+        """Reapply theme-dependent styles (screen bg, QR colors, icon tints)."""
+        # Screen background follows light/dark mode — otherwise the hardcoded
+        # bg from onCreate lingers after a theme toggle.
+        if AppearanceManager.is_light_mode():
+            self.main_screen.set_style_bg_color(lv.color_white(), lv.PART.MAIN)
+        else:
+            self.main_screen.set_style_bg_color(lv.color_hex(0x15171A), lv.PART.MAIN)
         dark, light = self._qr_colors()
         self.receive_qr.set_dark_color(dark)
         self.receive_qr.set_light_color(light)
         self.receive_qr.set_style_border_color(light, lv.PART.MAIN)
         if self.receive_qr_data:
             self.receive_qr.update(self.receive_qr_data, len(self.receive_qr_data))
+        # Settings-cog icon colour tracks the theme (white in dark mode, black in light).
+        if hasattr(self, 'settings_icon'):
+            self.settings_icon.set_style_text_color(self._icon_color(), lv.PART.MAIN)
         # Re-render balance in case denomination setting changed
         if hasattr(self, '_last_balance'):
             self.display_balance(self._last_balance)

--- a/tests/test_displaywallet_theme_override.py
+++ b/tests/test_displaywallet_theme_override.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for the app-local theme override helper in the Lightning Piggy app.
+
+Targets the app-local Light/Dark theme toggle. The override lives in the
+app's own prefs under `theme_override`; if set, it takes precedence over
+the OS-level theme but never writes to OS prefs.
+
+These tests cover the `_AppThemeView` adapter class that feeds
+AppearanceManager.init() a synthesised prefs view (override value + OS
+primary color) without touching OS prefs on disk.
+
+The vendored tests/unittest.sh auto-injects the app's assets/ dir into
+sys.path, so these imports work without any further path manipulation.
+
+Usage (from the LightningPiggyApp repo root):
+    Desktop: bash tests/unittest.sh tests/test_displaywallet_theme_override.py
+    Device:  bash tests/unittest.sh tests/test_displaywallet_theme_override.py --ondevice
+"""
+
+import unittest
+
+# The _AppThemeView class is defined at module-level in displaywallet.py.
+# Importing displaywallet pulls in LVGL+SettingsActivity machinery which is
+# heavy/noisy, but it works in the test harness. If the feature isn't landed
+# yet, _AppThemeView won't exist and the tests skip gracefully.
+try:
+    import displaywallet
+    _HAVE_APP_THEME_VIEW = hasattr(displaywallet, "_AppThemeView")
+except Exception:
+    _HAVE_APP_THEME_VIEW = False
+
+
+@unittest.skipUnless(_HAVE_APP_THEME_VIEW, "_AppThemeView not installed (feature not landed)")
+class TestAppThemeView(unittest.TestCase):
+    """The `_AppThemeView` duck-type mimics the `SharedPreferences.get_string`
+    surface needed by `AppearanceManager.init()`, so the theme can be
+    reinitialised with an app-local override without touching OS prefs."""
+
+    def test_returns_stored_theme_light_dark(self):
+        v = displaywallet._AppThemeView("dark", "0x1234AB")
+        self.assertEqual(v.get_string("theme_light_dark"), "dark")
+
+    def test_returns_stored_primary_color(self):
+        v = displaywallet._AppThemeView("light", "0xABCDEF")
+        self.assertEqual(v.get_string("theme_primary_color"), "0xABCDEF")
+
+    def test_unknown_key_returns_default(self):
+        v = displaywallet._AppThemeView("dark", "0x123456")
+        self.assertEqual(v.get_string("unrelated_key", "fallback"), "fallback")
+        # And None default when no default provided
+        self.assertIsNone(v.get_string("unrelated_key"))
+
+    def test_does_not_expose_set_or_edit(self):
+        # The view intentionally exposes only get_string — AppearanceManager.init
+        # reads from it and shouldn't try to write. Missing setters would be a
+        # regression.
+        v = displaywallet._AppThemeView("light", "0x000000")
+        self.assertFalse(hasattr(v, "set_string"))
+        self.assertFalse(hasattr(v, "edit"))
+
+
+@unittest.skipUnless(_HAVE_APP_THEME_VIEW, "_AppThemeView not installed")
+class TestAppThemeViewIntegrationWithAppearanceManager(unittest.TestCase):
+    """AppearanceManager.init() uses edit/put_string/commit on its prefs arg
+    when called from the setters — but *not* from init() itself, which only
+    reads via get_string. So an _AppThemeView (read-only) is compatible
+    with init() even though it has no edit() method."""
+
+    def test_init_reads_from_view_without_writing(self):
+        from mpos import AppearanceManager
+        saved = AppearanceManager.is_light_mode()
+        try:
+            v = displaywallet._AppThemeView("dark", "0xF0A010")
+            # Must not raise, must not attempt to write.
+            AppearanceManager.init(v)
+            self.assertFalse(AppearanceManager.is_light_mode())
+
+            v = displaywallet._AppThemeView("light", "0xF0A010")
+            AppearanceManager.init(v)
+            self.assertTrue(AppearanceManager.is_light_mode())
+        finally:
+            AppearanceManager._is_light_mode = saved
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest.sh
+++ b/tests/unittest.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# Vendored from MicroPythonOS/tests/unittest.sh so the LightningPiggy test
+# suite is self-contained and doesn't depend on the MicroPythonOS repo
+# layout. Kept as close to upstream as practical to ease future sync.
+#
+# Changes vs upstream:
+#   - MicroPythonOS checkout discovered via $MPOS_HOME (env var) with a
+#     ../MicroPythonOS sibling-directory default, instead of hardcoded
+#     relative paths.
+#   - The Lightning Piggy assets/ dir is auto-injected into sys.path so
+#     tests can `import wallet_cache` etc. without manual path hacks.
+
+mydir=$(readlink -f "$0")
+mydir=$(dirname "$mydir")
+testdir="$mydir"
+
+# Locate the MicroPythonOS checkout (needed for the desktop binary,
+# internal_filesystem, and mpremote). Precedence:
+#   1. $MPOS_HOME env var
+#   2. ../MicroPythonOS (sibling layout: /parent/{LightningPiggyApp,MicroPythonOS})
+if [ -n "$MPOS_HOME" ]; then
+	mpos=$(readlink -f "$MPOS_HOME")
+elif [ -d "$mydir/../../MicroPythonOS" ]; then
+	mpos=$(readlink -f "$mydir/../../MicroPythonOS")
+else
+	echo "ERROR: MicroPythonOS checkout not found."
+	echo "Set \$MPOS_HOME, or clone MicroPythonOS as a sibling of LightningPiggyApp."
+	exit 1
+fi
+
+scriptdir="$mpos/scripts"
+fs="$mpos/internal_filesystem"
+mpremote="$mpos/lvgl_micropython/lib/micropython/tools/mpremote/mpremote.py"
+#heapsize=8M
+heapsize=16M # on desktop, a bit more is warranted (different C library etc)
+
+# The Lightning Piggy app's assets/ dir — auto-injected into sys.path so
+# tests can `from payment import Payment`, `import wallet_cache`, etc.
+lp_assets=$(readlink -f "$mydir/../com.lightningpiggy.displaywallet/assets")
+if [ ! -d "$lp_assets" ]; then
+	echo "ERROR: Lightning Piggy assets dir not found at $lp_assets"
+	exit 1
+fi
+
+# Parse arguments
+ondevice=""
+onetest=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ondevice)
+            ondevice="yes"
+            ;;
+        *)
+            onetest="$1"
+            ;;
+    esac
+    shift
+done
+
+# print os and set binary
+os_name=$(uname -s)
+if [ "$os_name" = "Darwin" ]; then
+        echo "Running on macOS"
+        binary="$mpos"/lvgl_micropython/build/lvgl_micropy_macOS
+else
+        # other cases can be added here
+        echo "Running on $os_name"
+        binary="$mpos"/lvgl_micropython/build/lvgl_micropy_unix
+fi
+
+binary=$(readlink -f "$binary")
+if [ ! -x "$binary" ]; then
+	echo "ERROR: MicroPythonOS desktop binary not found/executable at $binary"
+	echo "Build it first: cd $mpos && bash scripts/build_mpos.sh \$(uname -s | tr A-Z a-z)"
+	exit 1
+fi
+chmod +x "$binary"
+
+# make sure no autostart is configured:
+rm -f "$fs"/data/com.micropythonos.settings/config.json
+
+one_test() {
+	file="$1"
+	if [ ! -f "$file" ]; then
+		echo "ERROR: $file is not a regular, existing file!"
+		exit 1
+	fi
+	pushd "$fs"
+	echo "Testing $file"
+
+	# Detect if this is a graphical test (filename contains "graphical")
+	if echo "$file" | grep -q "graphical"; then
+		echo "Detected graphical test - including boot and main files"
+		is_graphical=1
+		# Get absolute path to tests directory for imports
+		tests_abs_path=$(readlink -f "$testdir")
+	else
+		is_graphical=0
+	fi
+
+	if [ -z "$ondevice" ]; then
+		# Desktop execution
+		if [ $is_graphical -eq 1 ]; then
+			echo "Graphical test: include main.py"
+			"$binary" -X heapsize=$heapsize -c "import sys ; sys.path.insert(0, 'lib') ; sys.path.append(\"$tests_abs_path\") ; sys.path.append(\"$lp_assets\") ; import mpos ; mpos.TaskManager.disable() ; $(cat main.py)
+$(cat $file)
+result = unittest.main() ; sys.exit(0 if result.wasSuccessful() else 1) "
+	           result=$?
+		else
+			echo "Regular test: no boot files"
+			"$binary" -X heapsize=$heapsize -c "import sys ; sys.path.insert(0, 'lib') ; sys.path.append(\"$lp_assets\") ; import mpos ; mpos.TaskManager.disable() ; $(cat main.py)
+$(cat $file)
+result = unittest.main() ; sys.exit(0 if result.wasSuccessful() else 1) "
+	           result=$?
+		fi
+	else
+		if [ ! -z "$ondevice" ]; then
+			echo "Hack: reset the device to make sure no previous UnitTest classes have been registered..."
+			"$mpremote" reset
+			sleep 30
+		fi
+
+		echo "Device execution"
+		# NOTE: On device, the OS is already running with boot.py and main.py executed,
+		# so we don't need to (and shouldn't) re-run them. The system is already initialized.
+		# Lightning Piggy assets live at /apps/com.lightningpiggy.displaywallet/assets/
+		# on device — use that path instead of $lp_assets (which is host-side).
+		cleanname=$(echo "$file" | sed "s#/#_#g")
+		testlog=/tmp/"$cleanname".log
+		echo "$test logging to $testlog"
+		if [ $is_graphical -eq 1 ]; then
+			# Graphical test: system already initialized, just add test paths
+			"$mpremote" exec "import sys ; sys.path.insert(0, 'lib') ; sys.path.append('tests') ; sys.path.append('apps/com.lightningpiggy.displaywallet/assets') ; import mpos ; mpos.TaskManager.disable() ; $(cat main.py)
+$(cat $file)
+result = unittest.main()
+if result.wasSuccessful():
+		  print('TEST WAS A SUCCESS')
+else:
+		  print('TEST WAS A FAILURE')
+" | tee "$testlog"
+		else
+			# Regular test: no boot files
+			"$mpremote" exec "import sys ; sys.path.insert(0, 'lib') ; sys.path.append('tests') ; sys.path.append('apps/com.lightningpiggy.displaywallet/assets') ; import mpos ; mpos.TaskManager.disable() ; $(cat main.py)
+$(cat $file)
+result = unittest.main()
+if result.wasSuccessful():
+		  print('TEST WAS A SUCCESS')
+else:
+		  print('TEST WAS A FAILURE')
+" | tee "$testlog"
+		fi
+		grep -q "TEST WAS A SUCCESS" "$testlog"
+		result=$?
+	fi
+	popd
+	return "$result"
+}
+
+failed=0
+ran=0
+
+if [ -z "$onetest" ]; then
+	echo "Usage: $0 [one_test_to_run.py] [--ondevice]"
+	echo "Example: $0 tests/test_onchain_wallet.py"
+	echo "Example: $0 tests/test_onchain_wallet.py --ondevice"
+	echo "Example: $0 --ondevice"
+	echo
+	echo "If no test is specified: run all tests from $testdir on local machine."
+	echo
+	echo "The '--ondevice' flag will run the test(s) on a connected device using mpremote.py over a serial connection."
+	echo
+	echo "MicroPythonOS checkout resolved to: $mpos"
+	echo "Lightning Piggy assets resolved to: $lp_assets"
+	files=$(find "$testdir" -iname "test_*.py" )
+	for file in $files; do
+		one_test "$file"
+		result=$?
+		if [ $result -ne 0 ]; then
+			echo -e "\n\n\nWARNING: test $file got error $result !!!\n\n\n"
+			failed=$(expr $failed \+ 1)
+			exit 1
+		else
+			ran=$(expr $ran \+ 1)
+		fi
+	done
+else
+	echo "doing $onetest"
+	one_test $(readlink -f "$onetest")
+	result=$?
+	if [ $result -ne 0 ]; then
+		echo "Test returned result: $result"
+		failed=1
+	fi
+fi
+
+
+if [ $failed -ne 0 ]; then
+        echo "ERROR: $failed of the $ran tests failed"
+        exit 1
+else
+	echo "GOOD: none of the $ran tests failed"
+	exit 0
+fi


### PR DESCRIPTION
## Summary

Adds a per-app Light/Dark theme override in Customise settings. When set, the Lightning Piggy app renders in the chosen mode while the launcher and every other app keep the user's OS-level preference. No writes to OS prefs.

## How it works

- `_AppThemeView` — minimal prefs-like adapter that exposes only `get_string()`. Feeds `AppearanceManager.init()` a synthesised prefs view with the override value plus the unmodified OS primary color.
- `_apply_displaywallet_theme(prefs)` — looks at the app's own `theme_override` pref. If set to `light` or `dark`, applies via `_AppThemeView`; otherwise forwards OS prefs verbatim (no-op override).
- `CustomiseSettingsActivity` grows a **Theme** row that flips the override inline. The theme reinit is deferred via `lv.async_call` to avoid disturbing the current click event (LVGL's `theme_default_init` run during an event handler breaks subsequent tap handling).
- `onResume` calls `_apply_displaywallet_theme` every time so the override is applied on first launch too — not just after returning from Settings.
- `onPause` restores the OS-level theme on exit, so the launcher sees the user's OS preference unmodified.
- `_apply_qr_theme` also updates the settings-cog icon colour to track the effective theme.

Originally developed as 4 separate commits (feature + 3 device-testing bug-fixes); squashed to one for review.

## Tests

5 tests in `tests/test_displaywallet_theme_override.py`:
- `_AppThemeView` returns stored values
- Unknown key returns default (or None)
- No `set_string` / `edit` methods exposed (read-only by design)
- `AppearanceManager.init()` accepts the view without attempting writes (depends on MicroPythonOS/MicroPythonOS#120)

Also vendors `tests/unittest.sh` from MicroPythonOS (per @ThomasFarstrike's feedback on MicroPythonOS/MicroPythonOS#121 — app-specific tests should live with the app). Adapts it to discover the MicroPythonOS checkout via `$MPOS_HOME` or a `../MicroPythonOS` sibling-directory default.

Usage: `bash tests/unittest.sh tests/test_displaywallet_theme_override.py`. All 5 tests pass on macOS desktop.

## Release target

Bumps MANIFEST to `0.3.0` and adds a `0.3.0` CHANGELOG section.

Part of a four-PR split heading toward v0.3.0:
- **#27a (this PR)** — theme toggle
- **#27b** — pure-black dark mode polish (stacked on this)
- **#27c** (#29) — pre-v0.3.0 cleanup (independent)
- **#27d** (#28) — NWC secret scrub (security hotfix, ready-for-review)

## Dependency

Integration tests depend on MicroPythonOS/MicroPythonOS#120 (AppearanceManager.set_light_mode / set_primary_color fix) — without that PR merged, `AppearanceManager.init()` still reads from `_AppThemeView` correctly but downstream setters may fail. The unit tests here avoid triggering the setter paths.

## Test plan

- [ ] Settings → Customise → Theme: tap to flip, confirm UI updates live
- [ ] Verify OS theme stays at whatever it was (open launcher, confirm theme matches OS pref)
- [ ] First launch after setting an override in prefs directly — confirm override is applied without going through settings
- [ ] Exit app → relaunch → theme override persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)