### PR TITLE
BOOT button: re-attach the GPIO0 watcher on onResume

### DIFF
--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -1156,6 +1156,15 @@ class DisplayWallet(Activity):
 
     def onResume(self, main_screen):
         super().onResume(main_screen)
+        # Re-attach the BOOT-button watcher if it died while LP was in the
+        # background (e.g. MPOS auto-launched the WiFi-picker activity after
+        # a failed reconnect — observed at a new location with no saved
+        # networks in range — and our watcher task got cleaned up alongside
+        # whatever else MPOS tore down). `_start_boot_button_watcher` is
+        # idempotent (heartbeat check) so calling it on every onResume is
+        # cheap when the watcher is already running and is the load-bearing
+        # restart when it isn't.
+        self._start_boot_button_watcher()
         # Ensure the app's effective theme (local override or OS) is applied.
         # This never writes to OS prefs — see _apply_displaywallet_theme.
         _apply_displaywallet_theme(self.prefs)
@@ -1387,13 +1396,42 @@ class DisplayWallet(Activity):
 
     def _start_boot_button_watcher(self):
         """Wire up GPIO0 (BOOT button) for short/long press detection. Silent
-        no-op on desktop builds without machine.Pin."""
+        no-op on desktop builds without machine.Pin.
+
+        Idempotent: safe to call repeatedly. Checks for a still-alive watcher
+        task before starting a new one — without this, calling from both
+        onStart and onResume would spawn racing watchers that would each
+        flip `active_wallet_slot` on every press (back-and-forth), cancelling
+        the user's swap. The check uses the stored task handle's `.done()`
+        plus the `_boot_button_alive_ms` heartbeat the watcher loop updates
+        every iteration; a stale heartbeat means the task died silently
+        (the LP `MemoryError` traceback case from #45 demonstrated this is
+        possible) and we should restart it.
+        """
         try:
             from machine import Pin
         except ImportError:
             # Desktop build — no GPIO. Silently skip.
             self._boot_button_keep_running = False
             return
+
+        # Idempotency: if we have a task handle and it's not done, AND the
+        # heartbeat is recent (within 500 ms), the existing watcher is alive
+        # and there's nothing to do. Otherwise fall through and (re-)start.
+        existing = getattr(self, "_boot_button_task", None)
+        last_alive = getattr(self, "_boot_button_alive_ms", None)
+        if existing is not None:
+            try:
+                still_alive = not existing.done()
+            except Exception:
+                still_alive = True  # can't tell → assume alive, don't double-start
+            if still_alive and last_alive is not None:
+                if time.ticks_diff(time.ticks_ms(), last_alive) < 500:
+                    return
+            # Either the task is done or its heartbeat is stale — flag the
+            # old loop to exit, then fall through to start a fresh one.
+            self._boot_button_keep_running = False
+
         try:
             self._boot_button_pin = Pin(0, Pin.IN, Pin.PULL_UP)
         except Exception as e:
@@ -1401,7 +1439,9 @@ class DisplayWallet(Activity):
             self._boot_button_keep_running = False
             return
         self._boot_button_keep_running = True
-        TaskManager.create_task(self._boot_button_watcher_task())
+        self._boot_button_alive_ms = time.ticks_ms()
+        self._boot_button_task = TaskManager.create_task(self._boot_button_watcher_task())
+        print("BOOT button: watcher started")
 
     async def _boot_button_watcher_task(self):
         """Polling watcher with short/long press detection. Runs until onDestroy.
@@ -1419,6 +1459,10 @@ class DisplayWallet(Activity):
         pin = self._boot_button_pin
         debounce_s = self._BOOT_DEBOUNCE_MS / 1000
         while self._boot_button_keep_running:
+            # Heartbeat for the idempotency check in _start_boot_button_watcher
+            # — onResume reads this to decide whether the watcher is still
+            # alive or needs a restart. A stale value means we silently died.
+            self._boot_button_alive_ms = time.ticks_ms()
             try:
                 if pin.value() == 0:  # active LOW: pressed
                     await TaskManager.sleep(debounce_s)

--- a/com.lightningpiggy.displaywallet/assets/displaywallet.py
+++ b/com.lightningpiggy.displaywallet/assets/displaywallet.py
@@ -1143,9 +1143,10 @@ class DisplayWallet(Activity):
         # Initialize Confetti
         self.confetti = Confetti(main_screen, self.ICON_PATH, self.ASSET_PATH, self.confetti_duration)
 
-        # ESP32 BOOT button (GPIO0) — short press swaps active wallet, long
-        # press opens Settings. No-op on the desktop build (no machine.Pin).
-        self._start_boot_button_watcher()
+        # (The ESP32 BOOT-button watcher is started from onResume — the
+        # framework always fires onResume right after onStart on launch,
+        # and onResume alone when returning from the background, so one
+        # call site covers both paths.)
 
         # Periodic stale-indicator check — runs every 60 s so the dot
         # appears even across periods with no wallet events (e.g. WiFi
@@ -1156,14 +1157,16 @@ class DisplayWallet(Activity):
 
     def onResume(self, main_screen):
         super().onResume(main_screen)
-        # Re-attach the BOOT-button watcher if it died while LP was in the
-        # background (e.g. MPOS auto-launched the WiFi-picker activity after
-        # a failed reconnect — observed at a new location with no saved
-        # networks in range — and our watcher task got cleaned up alongside
-        # whatever else MPOS tore down). `_start_boot_button_watcher` is
-        # idempotent (heartbeat check) so calling it on every onResume is
-        # cheap when the watcher is already running and is the load-bearing
-        # restart when it isn't.
+        # Start — or re-attach — the ESP32 BOOT-button watcher (short press
+        # swaps the active wallet, long press opens Settings; no-op on
+        # desktop builds without machine.Pin). This is the only call site:
+        # the framework fires onResume right after onStart on launch, and
+        # onResume alone when LP returns from the background — where the
+        # watcher task may have died while another activity was in the
+        # foreground (observed on-device after a trip through the WiFi
+        # settings screen). `_start_boot_button_watcher` is idempotent
+        # (task-handle + heartbeat check) so the common already-running
+        # case is a cheap no-op.
         self._start_boot_button_watcher()
         # Ensure the app's effective theme (local override or OS) is applied.
         # This never writes to OS prefs — see _apply_displaywallet_theme.


### PR DESCRIPTION
## Summary

The BOOT-button → wallet-switch feature (added in #40) silently broke whenever LP was backgrounded by another activity — a trip through Settings, the WiFi settings screen, the Lightning-Piggy-Jump easter-egg, anything. The watcher task could get cleaned up while LP was in the background, and on returning to LP `onResume` fired (not `onStart`), so the watcher never came back. Short and long press both went silent until the user killed and re-launched LP.

Observed on-device after a manual trip through the WiFi settings screen at a new location: `TaskManager.list_tasks()` showed the watcher task gone, GPIO0 presses verified working at the pin level, but nothing listening.

## Fix

Three pieces in `displaywallet.py`:

### 1. `_start_boot_button_watcher` is now idempotent

```python
existing = getattr(self, "_boot_button_task", None)
last_alive = getattr(self, "_boot_button_alive_ms", None)
if existing is not None:
    try:
        still_alive = not existing.done()
    except Exception:
        still_alive = True   # can't tell → assume alive
    if still_alive and last_alive is not None:
        if time.ticks_diff(time.ticks_ms(), last_alive) < 500:
            return
    self._boot_button_keep_running = False    # tell old loop to exit
```

Calling it repeatedly was previously harmful — two racing watchers would each flip `active_wallet_slot` on every press, cancelling the user's swap. The check uses **both** `task.done()` **and** a freshness heartbeat: `done()` can miss a wedged task, the 500 ms heartbeat catches that.

### 2. Heartbeat in the watcher loop

The loop updates `self._boot_button_alive_ms = time.ticks_ms()` every iteration (~50 ms cadence). A stale value reliably signals "this task is no longer polling."

### 3. `onResume` is the single call site (review feedback)

The framework always fires `onResume` right after `onStart` on launch, and `onResume` alone when returning from the background — so one call site in `onResume` covers both paths. The original revision of this PR had the call in both hooks; the redundant `onStart` call was dropped in `ca57123` per review.

Common case (watcher alive after a quick Settings round-trip) → idempotency makes it a no-op. Pathological case (watcher died while backgrounded) → restart, button works again.

## Verified on device

Waveshare ESP32-S3-Touch-LCD-2, MicroPythonOS main:

| Step | Result |
|---|---|
| Open LP, configure both wallet slots, BOOT press swaps | ✓ Works (matches #40 behaviour) |
| Background LP (WiFi settings trip) → watcher gone from `TaskManager.list_tasks()` | ✓ Reproduces the original bug |
| Return to LP → `onResume` restarts the watcher (`_boot_button_watcher_task` back in the task list, heartbeat fresh) | ✓ |
| BOOT press after the round-trip → wallet flips on screen | ✓ |

The post-review revision (single call site) is the same logic minus the redundant call; re-verified via desktop build (syntax check + full test suite on this branch: 112 tests across 6 files, all green).

## Merge-checklist compliance

* **CHANGELOG.md**: entry added under 0.5.1 (the MANIFEST version is already at 0.5.1 on master for this cycle).
* **Tests**: `tests/test_boot_button_watcher.py` — 5 new tests covering the idempotency core (start-once, no-op while alive, restart on task-done, restart on stale heartbeat, desktop no-GPIO no-op) via a stub wallet + recording TaskManager + injected fake `machine` module. Full suite: 122 tests / 7 files, green. Activity-lifecycle transitions themselves remain manually verified on-device (table above) — the harness doesn't simulate backgrounding.
* **Settings**: no Setting definitions changed, no migration needed.
* Independent of #46 and #48.

