### PR TITLE
Tests: 56 new unit tests for NWC URL parsing, balance/transaction display logic, and the BOOT-watcher lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Synchronize confetti.py with MicroPythonOS' copy
 - BOOT button: re-attach the GPIO0 watcher on onResume
 - NostrService: don't use permissive ensure_lightning_prefix, only allow LUD-16
-- Test coverage: 56 new unit tests for the money paths — NWC URL parsing (both parser copies verified in lockstep), the balance state machine, live NIP-47 payment notifications (incoming/outgoing/msat rounding), receive-code `lightning:` prefixing, emoji surrogate-pair decoding, zap/LNURLp comment parsing, and the BOOT-button watcher lifecycle
+- Test coverage: 56 new unit tests for the display-critical paths — NWC URL parsing (both parser copies verified in lockstep), the balance state machine, live NIP-47 payment notifications (incoming/outgoing/msat rounding), receive-code `lightning:` prefixing, emoji surrogate-pair decoding, zap/LNURLp comment parsing, and the BOOT-button watcher lifecycle
 
 0.5.0
 =====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Synchronize confetti.py with MicroPythonOS' copy
 - BOOT button: re-attach the GPIO0 watcher on onResume
 - NostrService: don't use permissive ensure_lightning_prefix, only allow LUD-16
+- Test coverage: 56 new unit tests for the money paths — NWC URL parsing (both parser copies verified in lockstep), the balance state machine, live NIP-47 payment notifications (incoming/outgoing/msat rounding), receive-code `lightning:` prefixing, emoji surrogate-pair decoding, zap/LNURLp comment parsing, and the BOOT-button watcher lifecycle
 
 0.5.0
 =====

--- a/tests/test_boot_button_watcher.py
+++ b/tests/test_boot_button_watcher.py
@@ -1,0 +1,150 @@
+"""
+Unit tests for the ESP32 BOOT-button watcher lifecycle in displaywallet.py.
+
+Targets the onResume re-attach fix: `_start_boot_button_watcher` must be
+idempotent (calling it while a watcher is alive is a no-op) but must
+restart the watcher when the previous task died — detected via the task
+handle's done() and the `_boot_button_alive_ms` heartbeat the watcher
+loop refreshes every iteration.
+
+The method is exercised unbound against a stub object, with
+displaywallet's TaskManager swapped for a recorder and a fake `machine`
+module injected so the desktop build takes the real code path. The
+desktop-without-machine no-op path is covered too.
+
+Usage (from the LightningPiggyApp repo root):
+    Desktop: bash tests/unittest.sh tests/test_boot_button_watcher.py
+"""
+
+import sys
+import time
+import unittest
+
+try:
+    import displaywallet
+    _HAVE_WATCHER = hasattr(displaywallet.DisplayWallet, "_start_boot_button_watcher")
+except Exception:
+    _HAVE_WATCHER = False
+
+
+class _FakePin:
+    IN = 1
+    PULL_UP = 2
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def value(self):
+        return 1  # released
+
+
+class _FakeMachine:
+    """Stand-in for the `machine` module — `from machine import Pin`
+    resolves attributes off whatever object sits in sys.modules."""
+    Pin = _FakePin
+
+
+class _FakeTask:
+    def __init__(self):
+        self._done = False
+
+    def done(self):
+        return self._done
+
+
+class _RecordingTaskManager:
+    """Counts create_task calls and closes the coroutine immediately so
+    the watcher loop never actually runs in the test process."""
+
+    def __init__(self):
+        self.created = 0
+
+    def create_task(self, coro):
+        self.created += 1
+        try:
+            coro.close()
+        except Exception:
+            pass
+        return _FakeTask()
+
+
+class _StubWallet:
+    """Bare object for unbound method calls — the watcher methods set all
+    the attributes they need on first use. Only the coroutine factory the
+    starter passes to TaskManager.create_task has to exist up front."""
+
+    async def _boot_button_watcher_task(self):
+        pass  # never runs — the recording TaskManager closes the coroutine
+
+
+@unittest.skipUnless(_HAVE_WATCHER, "BOOT-button watcher not installed")
+class TestBootButtonWatcherLifecycle(unittest.TestCase):
+
+    def setUp(self):
+        self._orig_tm = displaywallet.TaskManager
+        self._had_machine = "machine" in sys.modules
+        self._orig_machine = sys.modules.get("machine")
+        self.tm = _RecordingTaskManager()
+        displaywallet.TaskManager = self.tm
+        sys.modules["machine"] = _FakeMachine
+
+    def tearDown(self):
+        displaywallet.TaskManager = self._orig_tm
+        if self._had_machine:
+            sys.modules["machine"] = self._orig_machine
+        else:
+            del sys.modules["machine"]
+
+    def _start(self, w):
+        displaywallet.DisplayWallet._start_boot_button_watcher(w)
+
+    def test_first_call_starts_the_watcher(self):
+        w = _StubWallet()
+        self._start(w)
+        self.assertEqual(self.tm.created, 1)
+        self.assertTrue(w._boot_button_keep_running)
+
+    def test_idempotent_while_watcher_alive(self):
+        # The fix calls _start_boot_button_watcher from onResume on every
+        # foreground return — when the watcher is alive (task not done,
+        # heartbeat fresh) that must be a no-op, otherwise two racing
+        # watchers would each flip the wallet slot per press.
+        w = _StubWallet()
+        self._start(w)
+        self._start(w)
+        self._start(w)
+        self.assertEqual(self.tm.created, 1)
+
+    def test_restarts_when_task_done(self):
+        w = _StubWallet()
+        self._start(w)
+        w._boot_button_task._done = True  # watcher task exited
+        self._start(w)
+        self.assertEqual(self.tm.created, 2)
+
+    def test_restarts_when_heartbeat_stale(self):
+        # task.done() can miss a wedged task — the heartbeat (refreshed by
+        # the watcher loop every ~50 ms) is the canonical liveness signal.
+        # 500 ms without a beat means the watcher silently died.
+        w = _StubWallet()
+        self._start(w)
+        w._boot_button_alive_ms = time.ticks_add(time.ticks_ms(), -5000)
+        self._start(w)
+        self.assertEqual(self.tm.created, 2)
+        # And the stale path must flag the old loop to exit before
+        # starting the new one... which the restart then re-enables.
+        self.assertTrue(w._boot_button_keep_running)
+
+    def test_desktop_without_machine_is_noop(self):
+        del sys.modules["machine"]  # simulate desktop build (no GPIO)
+        try:
+            w = _StubWallet()
+            self._start(w)
+            self.assertEqual(self.tm.created, 0)
+            self.assertFalse(w._boot_button_keep_running)
+        finally:
+            sys.modules["machine"] = _FakeMachine  # restore for tearDown
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nwc_url_parsing.py
+++ b/tests/test_nwc_url_parsing.py
@@ -1,0 +1,188 @@
+"""
+Unit tests for NWC (NIP-47 Nostr Wallet Connect) URL parsing.
+
+The codebase deliberately carries TWO copies of the parser:
+  - NWCWallet.parse_nwc_url   (nwc_wallet.py)    — feeds the wallet object
+  - NostrManager._parse_nwc_url (nostr_service.py) — feeds the relay layer
+
+Every NWC credential a user enters passes through both, so besides testing
+each parser's accept/reject behaviour, test_parsers_agree feeds the same
+battery of URLs to both and asserts identical outcomes — guarding against
+the copies drifting apart.
+
+Both methods ignore `self`, so they're exercised unbound with None.
+
+Usage (from the LightningPiggyApp repo root):
+    Desktop: bash tests/unittest.sh tests/test_nwc_url_parsing.py
+"""
+
+import sys
+import unittest
+
+# The MPOS nostr app's boot service can pre-load its own (older)
+# nostr_service into sys.modules, shadowing Lightning Piggy's copy —
+# purge so the imports below resolve to the app's own modules.
+for _m in ("nostr_service", "nwc_wallet", "wallet", "payment", "unique_sorted_list"):
+    if _m in sys.modules:
+        del sys.modules[_m]
+
+from nwc_wallet import NWCWallet
+from nostr_service import NostrManager
+
+PUBKEY = "ab" * 32  # 64 lowercase hex chars
+SECRET = "cd" * 32
+RELAY = "wss://relay.example.com"
+LUD16 = "piggy@example.com"
+
+VALID_URL = (
+    "nostr+walletconnect://" + PUBKEY
+    + "?relay=" + RELAY + "&secret=" + SECRET + "&lud16=" + LUD16
+)
+
+# Shaped like what coinos/Alby actually hand out: percent-encoded relay.
+REAL_WORLD_URL = (
+    "nostr+walletconnect://" + PUBKEY
+    + "?relay=wss%3A%2F%2Frelay.coinos.io&secret=" + SECRET
+    + "&lud16=" + LUD16
+)
+
+# (name, callable) for both parser copies — both return
+# (relays, pubkey, secret, lud16) and wrap any failure in RuntimeError.
+PARSERS = (
+    ("NWCWallet.parse_nwc_url", lambda url: NWCWallet.parse_nwc_url(None, url)),
+    ("NostrManager._parse_nwc_url", lambda url: NostrManager._parse_nwc_url(None, url)),
+)
+
+
+class TestNWCURLParsing(unittest.TestCase):
+
+    def _assert_rejected(self, url):
+        for name, parse in PARSERS:
+            try:
+                result = parse(url)
+            except RuntimeError:
+                continue  # expected
+            self.fail("{} accepted bad URL {!r} -> {!r}".format(name, url, result))
+
+    def test_full_url_parses(self):
+        for name, parse in PARSERS:
+            relays, pubkey, secret, lud16 = parse(VALID_URL)
+            self.assertEqual(relays, [RELAY], name)
+            self.assertEqual(pubkey, PUBKEY, name)
+            self.assertEqual(secret, SECRET, name)
+            self.assertEqual(lud16, LUD16, name)
+
+    def test_nwc_short_prefix(self):
+        url = "nwc:" + PUBKEY + "?relay=" + RELAY + "&secret=" + SECRET
+        for name, parse in PARSERS:
+            relays, pubkey, secret, lud16 = parse(url)
+            self.assertEqual(pubkey, PUBKEY, name)
+            self.assertEqual(lud16, None, name)
+
+    def test_missing_prefix_rejected(self):
+        self._assert_rejected(PUBKEY + "?relay=" + RELAY + "&secret=" + SECRET)
+
+    def test_urlencoded_relay_decoded(self):
+        for name, parse in PARSERS:
+            relays, _, _, lud16 = parse(REAL_WORLD_URL)
+            self.assertEqual(relays, ["wss://relay.coinos.io"], name)
+            self.assertEqual(lud16, LUD16, name)
+
+    def test_multiple_relays_collected(self):
+        url = (
+            "nostr+walletconnect://" + PUBKEY
+            + "?relay=wss://a.example&relay=wss://b.example&secret=" + SECRET
+        )
+        for name, parse in PARSERS:
+            relays, _, _, _ = parse(url)
+            self.assertEqual(relays, ["wss://a.example", "wss://b.example"], name)
+
+    def test_lud16_optional(self):
+        url = "nostr+walletconnect://" + PUBKEY + "?relay=" + RELAY + "&secret=" + SECRET
+        for name, parse in PARSERS:
+            _, _, _, lud16 = parse(url)
+            self.assertEqual(lud16, None, name)
+
+    def test_pubkey_wrong_length_rejected(self):
+        url = "nostr+walletconnect://" + ("ab" * 16) + "?relay=" + RELAY + "&secret=" + SECRET
+        self._assert_rejected(url)
+
+    def test_pubkey_uppercase_hex_rejected(self):
+        # Documents current strictness: only lowercase hex is accepted.
+        url = "nostr+walletconnect://" + PUBKEY.upper() + "?relay=" + RELAY + "&secret=" + SECRET
+        self._assert_rejected(url)
+
+    def test_pubkey_non_hex_rejected(self):
+        url = "nostr+walletconnect://" + ("zz" * 32) + "?relay=" + RELAY + "&secret=" + SECRET
+        self._assert_rejected(url)
+
+    def test_missing_secret_rejected(self):
+        self._assert_rejected("nostr+walletconnect://" + PUBKEY + "?relay=" + RELAY)
+
+    def test_secret_wrong_length_rejected(self):
+        url = "nostr+walletconnect://" + PUBKEY + "?relay=" + RELAY + "&secret=" + ("cd" * 8)
+        self._assert_rejected(url)
+
+    def test_missing_relay_rejected(self):
+        self._assert_rejected("nostr+walletconnect://" + PUBKEY + "?secret=" + SECRET)
+
+    def test_no_query_string_rejected(self):
+        self._assert_rejected("nostr+walletconnect://" + PUBKEY)
+
+    def test_parsers_agree(self):
+        # The drift guard: identical outcome (same tuple, or both reject)
+        # for every URL in the battery.
+        battery = [
+            VALID_URL,
+            REAL_WORLD_URL,
+            "nwc:" + PUBKEY + "?relay=" + RELAY + "&secret=" + SECRET,
+            "nostr+walletconnect://" + PUBKEY + "?relay=wss://a&relay=wss://b&secret=" + SECRET,
+            # invalid ones:
+            PUBKEY + "?relay=" + RELAY + "&secret=" + SECRET,
+            "nostr+walletconnect://" + PUBKEY,
+            "nostr+walletconnect://" + PUBKEY + "?relay=" + RELAY,
+            "nostr+walletconnect://" + PUBKEY + "?relay=" + RELAY + "&secret=short",
+            "nostr+walletconnect://short?relay=" + RELAY + "&secret=" + SECRET,
+            "",
+        ]
+        for url in battery:
+            outcomes = []
+            for name, parse in PARSERS:
+                try:
+                    outcomes.append(parse(url))
+                except RuntimeError:
+                    outcomes.append("rejected")
+            self.assertEqual(
+                outcomes[0], outcomes[1],
+                "parsers disagree on {!r}: {!r} vs {!r}".format(url, outcomes[0], outcomes[1]),
+            )
+
+
+class TestNWCWalletConstructor(unittest.TestCase):
+
+    def test_valid_url_populates_wallet(self):
+        w = NWCWallet(VALID_URL)
+        self.assertEqual(w.slot_key, "nwc")
+        self.assertEqual(w.relays, [RELAY])
+        self.assertEqual(w.wallet_pubkey, PUBKEY)
+        self.assertEqual(w.secret, SECRET)
+        self.assertEqual(w.lud16, LUD16)
+
+    def test_empty_url_raises_valueerror(self):
+        for bad in ("", None):
+            try:
+                NWCWallet(bad)
+            except ValueError:
+                continue
+            self.fail("NWCWallet({!r}) did not raise ValueError".format(bad))
+
+    def test_malformed_url_raises(self):
+        try:
+            NWCWallet("nostr+walletconnect://" + PUBKEY)  # no relay/secret
+        except RuntimeError:
+            return
+        self.fail("NWCWallet with malformed URL did not raise")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wallet_logic.py
+++ b/tests/test_wallet_logic.py
@@ -1,0 +1,335 @@
+"""
+Unit tests for the money-path logic in wallet.py and nwc_wallet.py:
+
+  - ensure_lightning_prefix      (QR receive-code prefixing, wallet.py)
+  - Wallet.handle_new_balance    (balance state machine + callback deltas)
+  - NWCWallet._mgr_notification_cb (live NIP-47 payment notifications)
+  - Wallet._decode_surrogate_pairs (emoji tofu fix)
+  - Wallet.try_parse_as_zap + NWCWallet.getCommentFromTransaction
+
+All pure logic — no network, no LVGL. TaskManager is swapped for a
+recorder that closes coroutines unrun, and wallets get slot_key=None so
+wallet_cache writes are no-ops (the base-class guard).
+
+Note: nostr_service intentionally does NOT use ensure_lightning_prefix
+anymore (commit 53960e8 — lud16 from an NWC URL is only forwarded when
+it looks like a LUD-16, i.e. contains "@"). The function remains the
+prefixing helper for displaywallet's QR paths, which is what these
+tests pin down.
+
+Usage (from the LightningPiggyApp repo root):
+    Desktop: bash tests/unittest.sh tests/test_wallet_logic.py
+"""
+
+import json
+import sys
+import unittest
+
+# The MPOS nostr app's boot service can pre-load its own (older)
+# nostr_service into sys.modules, shadowing Lightning Piggy's copy —
+# purge so the imports below resolve to the app's own modules.
+for _m in ("nostr_service", "nwc_wallet", "wallet", "payment", "unique_sorted_list"):
+    if _m in sys.modules:
+        del sys.modules[_m]
+
+import wallet
+from wallet import Wallet, ensure_lightning_prefix
+from nwc_wallet import NWCWallet
+
+NWC_URL = (
+    "nostr+walletconnect://" + ("ab" * 32)
+    + "?relay=wss://relay.example.com&secret=" + ("cd" * 32)
+)
+
+
+class _FakeTask:
+    def done(self):
+        return False
+
+
+class _RecordingTaskManager:
+    """Counts create_task calls and closes the coroutine immediately so
+    no wallet task actually runs in the test process."""
+
+    def __init__(self):
+        self.created = 0
+
+    def create_task(self, coro):
+        self.created += 1
+        try:
+            coro.close()
+        except Exception:
+            pass
+        return _FakeTask()
+
+
+class _TestWallet(Wallet):
+    """Minimal concrete wallet: only the coroutine factory that
+    handle_new_balance schedules has to exist."""
+
+    async def fetch_payments(self):
+        pass
+
+
+class TestEnsureLightningPrefix(unittest.TestCase):
+
+    def test_empty_and_none_pass_through(self):
+        self.assertEqual(ensure_lightning_prefix(""), "")
+        self.assertEqual(ensure_lightning_prefix(None), None)
+
+    def test_already_prefixed_unchanged(self):
+        self.assertEqual(
+            ensure_lightning_prefix("lightning:piggy@example.com"),
+            "lightning:piggy@example.com")
+
+    def test_prefix_check_is_case_insensitive(self):
+        self.assertEqual(
+            ensure_lightning_prefix("LIGHTNING:piggy@example.com"),
+            "LIGHTNING:piggy@example.com")
+
+    def test_other_uri_schemes_unchanged(self):
+        for code in ("bitcoin:bc1qexample", "http://example.com/lnurlp",
+                     "https://example.com/.well-known/lnurlp/piggy",
+                     "mailto:piggy@example.com"):
+            self.assertEqual(ensure_lightning_prefix(code), code)
+
+    def test_lud16_gets_prefixed(self):
+        self.assertEqual(
+            ensure_lightning_prefix("piggy@example.com"),
+            "lightning:piggy@example.com")
+
+    def test_lnurl_bech32_gets_prefixed(self):
+        self.assertEqual(
+            ensure_lightning_prefix("LNURL1DP68GURN8GHJ7MRWW4EXCTNZD9NHXATW"),
+            "lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNZD9NHXATW")
+
+    def test_bolt11_invoices_get_prefixed(self):
+        for inv in ("lnbc210n1example", "lntb210n1example", "lnbcrt210n1example"):
+            self.assertEqual(ensure_lightning_prefix(inv), "lightning:" + inv)
+
+    def test_unknown_format_unchanged(self):
+        self.assertEqual(ensure_lightning_prefix("foobar"), "foobar")
+
+    def test_whitespace_stripped_before_prefixing(self):
+        self.assertEqual(
+            ensure_lightning_prefix("  piggy@example.com "),
+            "lightning:piggy@example.com")
+
+
+class TestHandleNewBalance(unittest.TestCase):
+
+    def setUp(self):
+        self._orig_tm = wallet.TaskManager
+        self.tm = _RecordingTaskManager()
+        wallet.TaskManager = self.tm
+        self.w = _TestWallet()
+        self.deltas = []
+        self.w.balance_updated_cb = self.deltas.append
+
+    def tearDown(self):
+        wallet.TaskManager = self._orig_tm
+
+    def test_first_balance_fires_with_zero_delta_even_when_zero(self):
+        # A brand-new empty wallet must still update the UI (show "0").
+        self.w.handle_new_balance(0)
+        self.assertEqual(self.deltas, [0])
+        self.assertEqual(self.w.last_known_balance, 0)
+        self.assertEqual(self.tm.created, 1)  # initial payments fetch
+
+    def test_first_balance_can_skip_payments_fetch(self):
+        self.w.handle_new_balance(42, False)
+        self.assertEqual(self.deltas, [0])
+        self.assertEqual(self.tm.created, 0)
+
+    def test_change_fires_signed_delta(self):
+        self.w.handle_new_balance(100)
+        self.w.handle_new_balance(121)
+        self.w.handle_new_balance(100)
+        self.assertEqual(self.deltas, [0, 21, -21])
+        self.assertEqual(self.w.last_known_balance, 100)
+
+    def test_unchanged_balance_is_silent(self):
+        self.w.handle_new_balance(100)
+        created_after_first = self.tm.created
+        self.w.handle_new_balance(100)
+        self.assertEqual(self.deltas, [0])
+        self.assertEqual(self.tm.created, created_after_first)
+
+    def test_none_balance_ignored(self):
+        self.w.handle_new_balance(None)
+        self.assertEqual(self.deltas, [])
+        self.assertEqual(self.w.last_known_balance, None)
+
+    def test_stopped_wallet_ignores_balance(self):
+        self.w.keep_running = False
+        self.w.handle_new_balance(100)
+        self.assertEqual(self.deltas, [])
+        self.assertEqual(self.w.last_known_balance, None)
+
+
+class TestNWCNotifications(unittest.TestCase):
+
+    def setUp(self):
+        self._orig_tm = wallet.TaskManager
+        self.tm = _RecordingTaskManager()
+        wallet.TaskManager = self.tm
+        self.w = NWCWallet(NWC_URL)
+        self.w.slot_key = None  # keep wallet_cache writes out of unit tests
+        self.deltas = []
+        self.payment_pings = []
+        self.qr_pings = []
+        self.polls = []
+        self.w.balance_updated_cb = self.deltas.append
+        self.w.payments_updated_cb = lambda: self.payment_pings.append(1)
+        self.w.static_receive_code_updated_cb = lambda: self.qr_pings.append(1)
+        self.w.poll_success_cb = lambda: self.polls.append(1)
+
+    def tearDown(self):
+        wallet.TaskManager = self._orig_tm
+
+    def test_incoming_with_no_prior_balance(self):
+        self.w._mgr_notification_cb({
+            "type": "incoming", "amount": 21000,
+            "created_at": 1767713767, "description": "Good",
+        })
+        self.assertEqual(self.w.last_known_balance, 21)  # 21000 msat -> 21 sats
+        self.assertEqual(self.deltas, [0])  # first balance: delta 0
+        self.assertEqual(len(self.w.payment_list), 1)
+        payment = self.w.payment_list.get(0)
+        self.assertEqual(payment.amount_sats, 21)
+        self.assertEqual(payment.comment, "Good")
+        self.assertEqual(self.payment_pings, [1])
+        # incoming path must NOT schedule a payments refetch — the
+        # notification itself carries the payment.
+        self.assertEqual(self.tm.created, 0)
+
+    def test_incoming_adds_to_known_balance(self):
+        self.w.last_known_balance = 100
+        self.w._mgr_notification_cb({
+            "type": "incoming", "amount": 21000,
+            "created_at": 1767713767, "description": "tip",
+        })
+        self.assertEqual(self.w.last_known_balance, 121)
+        self.assertEqual(self.deltas, [21])
+
+    def test_msat_rounding(self):
+        self.w._mgr_notification_cb({
+            "type": "incoming", "amount": 1499,
+            "created_at": 1767713767, "description": "",
+        })
+        self.assertEqual(self.w.last_known_balance, 1)  # round(1.499)
+
+    def test_outgoing_applies_immediately_as_negative(self):
+        # Since the 0.5.1 outgoing fix, a send mirrors the incoming
+        # branch with a negative amount: balance and list update
+        # immediately instead of waiting for the next poll.
+        self.w.last_known_balance = 100
+        self.w._mgr_notification_cb({
+            "type": "outgoing", "amount": 5000,
+            "created_at": 1767713767, "description": "",
+        })
+        self.assertEqual(self.w.last_known_balance, 95)
+        self.assertEqual(self.deltas, [-5])
+        self.assertEqual(len(self.w.payment_list), 1)
+        self.assertEqual(self.w.payment_list.get(0).amount_sats, -5)
+        self.assertEqual(self.polls, [1])
+
+    def test_outgoing_without_prior_balance_skips_balance_math(self):
+        # No baseline to subtract from — balance stays unknown rather
+        # than going negative, but the payment still lands in the list.
+        self.w._mgr_notification_cb({
+            "type": "outgoing", "amount": 5000,
+            "created_at": 1767713767, "description": "",
+        })
+        self.assertEqual(self.w.last_known_balance, None)
+        self.assertEqual(self.deltas, [])
+        self.assertEqual(len(self.w.payment_list), 1)
+        self.assertEqual(self.w.payment_list.get(0).amount_sats, -5)
+
+    def test_unknown_type_ignored_without_crash(self):
+        self.w._mgr_notification_cb({
+            "type": "sideways", "amount": 5000,
+            "created_at": 1767713767, "description": "",
+        })
+        self.assertEqual(self.w.last_known_balance, None)
+        self.assertEqual(len(self.w.payment_list), 0)
+
+    def test_static_receive_code_notification_routed(self):
+        self.w._mgr_notification_cb({"static_receive_code": "piggy@example.com"})
+        self.assertEqual(self.w.static_receive_code, "piggy@example.com")
+        self.assertEqual(self.qr_pings, [1])
+        self.assertEqual(self.deltas, [])  # no balance side effects
+
+
+class TestSurrogatePairDecoding(unittest.TestCase):
+    # _decode_surrogate_pairs ignores self -> exercised unbound.
+
+    def _decode(self, text):
+        return Wallet._decode_surrogate_pairs(None, text)
+
+    def test_escaped_emoji_decodes_to_single_codepoint(self):
+        # Build the input the way it reaches the app: JSON with a
+        # 🙂 escape ("slightly smiling face"). Whether the JSON
+        # stack keeps surrogates or collapses them, the result after
+        # _decode_surrogate_pairs must be the real code point.
+        text = json.loads('"\\ud83d\\ude42"')
+        self.assertEqual(self._decode(text), chr(0x1F642))
+
+    def test_surrounding_text_preserved(self):
+        text = json.loads('"gm \\ud83d\\ude42!"')
+        self.assertEqual(self._decode(text), "gm " + chr(0x1F642) + "!")
+
+    def test_plain_ascii_unchanged(self):
+        self.assertEqual(self._decode("just sats"), "just sats")
+
+    def test_non_string_input_returned_as_is(self):
+        self.assertEqual(self._decode(None), None)
+        self.assertEqual(self._decode(42), 42)
+
+
+class TestCommentParsing(unittest.TestCase):
+
+    def setUp(self):
+        self._orig_tm = wallet.TaskManager
+        wallet.TaskManager = _RecordingTaskManager()
+        self.w = NWCWallet(NWC_URL)
+        self.w.slot_key = None
+
+    def tearDown(self):
+        wallet.TaskManager = self._orig_tm
+
+    def test_zap_json_extracts_content(self):
+        zap = '{"content": "Great piggy!", "kind": 9734, "pubkey": "ee"}'
+        self.assertEqual(self.w.try_parse_as_zap(zap), "zapped - Great piggy!")
+
+    def test_plain_comment_passes_through(self):
+        self.assertEqual(self.w.try_parse_as_zap("hello"), "hello")
+
+    def test_json_without_content_passes_through(self):
+        self.assertEqual(self.w.try_parse_as_zap('{"foo": 1}'), '{"foo": 1}')
+
+    def test_lnurlp_metadata_array_takes_text_plain(self):
+        desc = '[["text/identifier","piggy@example.com"],["text/plain","Thanks!"]]'
+        comment = self.w.getCommentFromTransaction({"description": desc})
+        self.assertEqual(comment, "Thanks!")
+
+    def test_null_description_returns_none(self):
+        self.assertEqual(
+            self.w.getCommentFromTransaction({"description": None}), None)
+
+    def test_plain_text_description_used_as_is(self):
+        self.assertEqual(
+            self.w.getCommentFromTransaction({"description": "hello"}), "hello")
+
+    def test_missing_description_yields_empty(self):
+        self.assertEqual(self.w.getCommentFromTransaction({}), "")
+
+    def test_zap_description_detected(self):
+        desc = '{"content": "gm", "kind": 9734}'
+        self.assertEqual(
+            self.w.getCommentFromTransaction({"description": desc}),
+            "zapped - gm")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tests-only PR — no production code changes. Adds coverage for the highest-value untested logic: the code that turns NWC credentials and payment events into balances and list entries.

## What's covered

**`tests/test_nwc_url_parsing.py` (17 tests)**
- `NWCWallet.parse_nwc_url` and `NostrManager._parse_nwc_url`: `nostr+walletconnect://` and `nwc:` prefixes, percent-encoded relays (the coinos/Alby shape), multiple relays, optional `lud16`, pubkey/secret 64-lowercase-hex validation, rejection of missing relay/secret/prefix.
- A **consistency battery** feeding the same valid + invalid URLs to *both* parser copies and asserting identical outcomes — the codebase intentionally carries two (wallet layer + relay layer), and this pins them together so they can't silently drift apart.
- `NWCWallet` constructor validation (populates slot/relays/lud16; `ValueError` on empty, parse errors propagate).

**`tests/test_wallet_logic.py` (34 tests)**
- `ensure_lightning_prefix`: all documented branches (idempotent, case-insensitive, `bitcoin:`/`http(s):`/`mailto:` passthrough, lud16/LNURL/BOLT11 prefixing, whitespace, unknown formats untouched). Note: tests document that `nostr_service` intentionally *doesn't* use this anymore (53960e8) — it remains the prefixing helper for displaywallet's QR paths.
- `Wallet.handle_new_balance` state machine: first balance fires the callback with delta 0 **even when the balance is 0 sats** (empty piggy must still render), signed deltas on change, silence on no-change, `None`/stopped guards, `fetchPaymentsIfChanged` behavior.
- `NWCWallet._mgr_notification_cb`: incoming adds msat→sat-rounded amounts to the known balance (and handles the no-prior-balance case), **outgoing applies immediately as a negative amount** (pinning the 0.5.1 fix from #48 as a regression test), outgoing with no baseline skips the subtraction rather than going negative, unknown types are ignored without crashing, `static_receive_code` notifications route to the QR callback with no balance side effects.
- `Wallet._decode_surrogate_pairs`: escaped emoji JSON (`🙂`) decodes to the real code point with surrounding text preserved; non-string inputs pass through.
- Comment parsing: zap-JSON content extraction, LNURLp metadata arrays (`text/plain` wins), `description: null`, missing description, plain text passthrough.

**`tests/test_boot_button_watcher.py` (5 tests)**
- The watcher-idempotency tests written for #47 — that PR was merged shortly before they were pushed to its branch, so they land here instead: start-once, no-op while alive, restart on `task.done()`, restart on stale heartbeat, desktop-without-`machine` no-op.

## How

Everything runs as pure logic on the desktop binary: `TaskManager` swapped for a recorder that closes coroutines unrun, wallets given `slot_key=None` so `wallet_cache` writes no-op, `machine` faked where needed, and the usual `sys.modules` purge so the MPOS nostr app's copy of `nostr_service` can't shadow this app's.

## Verification

`bash tests/unittest.sh`: **195 tests across 10 files, all green** (139 existing + 56 new).

## Merge checklist

- CHANGELOG entry added under 0.5.1.
- No production code, settings, or docs changes; MANIFEST already at 0.5.1 this cycle.