### PR TITLE
README: add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Lightning Piggy
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/LightningPiggy/LightningPiggyApp)
+
 MicroPythonOS display wallet: shows balance, transactions, a receive QR code,
 and more. Supports LNBits, Nostr Wallet Connect, and on-chain (xpub via
 Blockbook) wallet types. See https://www.LightningPiggy.com.


### PR DESCRIPTION
Adds the DeepWiki badge to the top of the README, matching the one the classic [lightning-piggy repo](https://github.com/LightningPiggy/lightning-piggy) already carries (its `4a59a53`), with the link pointing at this repo's own DeepWiki page: https://deepwiki.com/LightningPiggy/LightningPiggyApp (verified live, HTTP 200).

README-only; no code or packaged-app changes, so no CHANGELOG entry or version bump (the CHANGELOG tracks app releases and this does not ship in the .mpk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)